### PR TITLE
Proxy updates

### DIFF
--- a/lib/Ptero/Builder/Workflow.pm
+++ b/lib/Ptero/Builder/Workflow.pm
@@ -52,7 +52,10 @@ sub submit {
             Data::Dump::pp($submission_data), $response->content;
     }
 
-    return Ptero::Proxy::Workflow->new(url => $response->header('Location'));
+    return Ptero::Proxy::Workflow->new(
+        url => $response->header('Location'),
+        resource => Ptero::HTTP::decode_response($response),
+    );
 }
 
 sub create_task {

--- a/lib/Ptero/Builder/Workflow.pm
+++ b/lib/Ptero/Builder/Workflow.pm
@@ -420,7 +420,6 @@ sub submission_data {
     my $self = shift;
     my %p = Params::Validate::validate(@_, {
         inputs => {type => HASHREF, optional => 1},
-        parallel_by => {type => SCALAR, optional => 1},
     });
 
     $self->validate;
@@ -433,10 +432,6 @@ sub submission_data {
 
     if (exists $p{inputs}) {
         $hashref->{inputs} = $p{inputs};
-    }
-
-    if (exists $p{parallel_by}) {
-        $hashref->{parallelBy} = $p{parallel_by};
     }
 
     return $hashref;

--- a/lib/Ptero/HTTP.pm
+++ b/lib/Ptero/HTTP.pm
@@ -55,10 +55,15 @@ sub make_request {
 
     $logger->info(sprintf("Got %d from %s  %s", $response->code,
             uc($method), $url));
-    $logger->debug("    Headers: " . $req->{_headers}->as_string);
-    $logger->debug("    Data: " . pp($data));
+    $logger->debug("    Request \n" . indent($req->as_string, 4));
+    $logger->debug("    Response: \n" . indent($response->as_string, 4));
 
     return $response
+}
+
+sub indent {
+    my ($string, $num_spaces) = @_;
+    return join("\n", map {" "x$num_spaces . $_} split(/\n/,$string));
 }
 
 sub get   { make_request('GET',   @_) }

--- a/lib/Ptero/Proxy/Workflow.pm
+++ b/lib/Ptero/Proxy/Workflow.pm
@@ -20,6 +20,39 @@ has status_url => (
     predicate => 'has_status_url',
 );
 
+
+has resource => (
+    is => 'ro',
+    isa => 'HashRef',
+    required => 1
+);
+
+# This allows ->new($url) as well as ->new(url => $url) construction styles
+around BUILDARGS => sub {
+    my $orig  = shift;
+    my $class = shift;
+
+    if (@_ == 1 && !ref $_[0]) {
+        return $class->$orig(url => $_[0]);
+    }
+    else {
+        return $class->$orig(@_);
+    }
+};
+
+# This fetches the resource unless it was passed in at construction.
+sub BUILDARGS {
+    my ($class, %args) = @_;
+
+    unless ($args{resource}) {
+        unless ($args{url}) {
+            die "Cannot create a Ptero::Proxy::Workflow without a url";
+        }
+        $args{resource} = get_decoded_resource(url => $args{url});
+    }
+    return \%args;
+}
+
 sub wait {
     my $self = shift;
     my %p = Params::Validate::validate(@_, {

--- a/t/integration/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/result.json
+++ b/t/integration/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/result.json
@@ -1,0 +1,12 @@
+{
+    "outputs": {
+        "out_outer_parallel": [
+            ["kittens", "kittens", "kittens"],
+            ["puppies", "puppies", "puppies"]
+        ],
+        "out_inner_parallel": [
+            ["Simba", "Tabby", "Emilio"],
+            ["Simba", "Tabby", "Emilio"]
+        ]
+    }
+}

--- a/t/integration/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
+++ b/t/integration/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/submit.json
@@ -1,0 +1,135 @@
+{
+  "links": [
+    {
+      "destination": "A",
+      "destinationProperty": "in_outer_parallel",
+      "source": "input connector",
+      "sourceProperty": "in_outer_parallel"
+    },
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_outer_parallel",
+      "source": "A",
+      "sourceProperty": "out_outer_parallel"
+    },
+    {
+      "destination": "A",
+      "destinationProperty": "in_inner_parallel",
+      "source": "input connector",
+      "sourceProperty": "in_inner_parallel"
+    },
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_inner_parallel",
+      "source": "A",
+      "sourceProperty": "out_inner_parallel"
+    }
+  ],
+  "tasks": {
+    "A": {
+      "methods": [
+        {
+          "name": "inner",
+          "parameters": {
+            "links": [
+              {
+                "destination": "Inner",
+                "destinationProperty": "animal_type_in",
+                "source": "input connector",
+                "sourceProperty": "in_outer_parallel"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_outer_parallel",
+                "source": "Inner",
+                "sourceProperty": "animal_type_out"
+              },
+              {
+                "destination": "Inner",
+                "destinationProperty": "kitten_name_in",
+                "source": "input connector",
+                "sourceProperty": "in_inner_parallel"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_inner_parallel",
+                "source": "Inner",
+                "sourceProperty": "kitten_name_out"
+              }
+            ],
+            "tasks": {
+              "Inner": {
+                "methods": [
+                  {
+                    "name": "some_workflow",
+                    "parameters": {
+                      "links": [
+                        {
+                          "destination": "A",
+                          "destinationProperty": "animal_type",
+                          "source": "input connector",
+                          "sourceProperty": "animal_type_in"
+                        },
+                        {
+                          "destination": "output connector",
+                          "destinationProperty": "animal_type_out",
+                          "source": "A",
+                          "sourceProperty": "animal_type"
+                        },
+                        {
+                          "destination": "A",
+                          "destinationProperty": "kitten_name",
+                          "source": "input connector",
+                          "sourceProperty": "kitten_name_in"
+                        },
+                        {
+                          "destination": "output connector",
+                          "destinationProperty": "kitten_name_out",
+                          "source": "A",
+                          "sourceProperty": "kitten_name"
+                        }
+                      ],
+                      "tasks": {
+                        "A": {
+                          "methods": [
+                            {
+                              "name": "execute",
+                              "parameters": {
+                                "commandLine": [
+                                  "./echo_command"
+                                ],
+                                "environment": {{ environment }},
+                                "user": "{{ user }}",
+                                "workingDirectory": "{{ workingDirectory }}"
+                              },
+                              "service": "shell-command"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    "service": "workflow"
+                  }
+                ],
+                "parallelBy": "kitten_name_in"
+              }
+            }
+          },
+          "service": "workflow"
+        }
+      ],
+      "parallelBy": "in_outer_parallel"
+    }
+  },
+  "inputs": {
+    "in_outer_parallel": [
+      "kittens",
+      "puppies"
+    ],
+    "in_inner_parallel": [
+      "Simba",
+      "Tabby",
+      "Emilio"
+    ]
+  }
+}

--- a/t/integration/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/test.t
+++ b/t/integration/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/test.t
@@ -1,0 +1,3 @@
+use Ptero::TestHelper qw(run_test);
+
+run_test(__FILE__);

--- a/t/integration/workflow_tests/nested_parallel_by_operation_matrix_inputs/submit.json
+++ b/t/integration/workflow_tests/nested_parallel_by_operation_matrix_inputs/submit.json
@@ -1,44 +1,75 @@
 {
-    "parallelBy": "in_matrix",
-
-    "tasks": {
-        "A": {
-            "methods": [
-                {
-                    "name": "execute",
-                    "service": "shell-command",
-                    "parameters": {
-                        "commandLine": ["./echo_command"],
-                        "user": "{{ user }}",
-                        "workingDirectory": "{{ workingDirectory }}",
-                        "environment": {{ environment }}
-                    }
-                }
-            ],
-            "parallelBy": "name"
-        }
+  "links": [
+    {
+      "destination": "A",
+      "destinationProperty": "in_matrix",
+      "source": "input connector",
+      "sourceProperty": "in_matrix"
     },
-
-    "links": [
-        {
-            "source": "input connector",
-            "destination": "A",
-            "sourceProperty": "in_matrix",
-            "destinationProperty": "name"
-        },
-
-        {
-            "source": "A",
-            "destination": "output connector",
-            "sourceProperty": "name",
-            "destinationProperty": "out_matrix"
-        }
-    ],
-
-    "inputs": {
-        "in_matrix": [
-            ["Simba", "Tabby", "Emilio"],
-            ["Pluto", "Snoopy"]
-        ]
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_matrix",
+      "source": "A",
+      "sourceProperty": "out_matrix"
     }
+  ],
+  "tasks": {
+    "A": {
+      "methods": [
+        {
+          "name": "inner",
+          "parameters": {
+            "links": [
+              {
+                "destination": "A",
+                "destinationProperty": "name",
+                "source": "input connector",
+                "sourceProperty": "in_matrix"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_matrix",
+                "source": "A",
+                "sourceProperty": "name"
+              }
+            ],
+            "tasks": {
+              "A": {
+                "methods": [
+                  {
+                    "name": "execute",
+                    "parameters": {
+                      "commandLine": [
+                        "./echo_command"
+                      ],
+                      "environment": {{ environment }},
+                      "user": "{{ user }}",
+                      "workingDirectory": "{{ workingDirectory }}"
+                    },
+                    "service": "shell-command"
+                  }
+                ],
+                "parallelBy": "name"
+              }
+            }
+          },
+          "service": "workflow"
+        }
+      ],
+      "parallelBy": "in_matrix"
+    }
+  },
+  "inputs": {
+    "in_matrix": [
+      [
+        "Simba",
+        "Tabby",
+        "Emilio"
+      ],
+      [
+        "Pluto",
+        "Snoopy"
+      ]
+    ]
+  }
 }

--- a/t/integration/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/result.json
+++ b/t/integration/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/result.json
@@ -1,0 +1,12 @@
+{
+    "outputs": {
+        "out_outer_parallel": [
+            ["kittens", "kittens", "kittens"],
+            ["puppies", "puppies", "puppies"]
+        ],
+        "out_inner_parallel": [
+            ["Simba", "Tabby", "Emilio"],
+            ["Simba", "Tabby", "Emilio"]
+        ]
+    }
+}

--- a/t/integration/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
+++ b/t/integration/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/submit.json
@@ -1,0 +1,97 @@
+{
+  "links": [
+    {
+      "destination": "A",
+      "destinationProperty": "in_outer_parallel",
+      "source": "input connector",
+      "sourceProperty": "in_outer_parallel"
+    },
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_outer_parallel",
+      "source": "A",
+      "sourceProperty": "out_outer_parallel"
+    },
+    {
+      "destination": "A",
+      "destinationProperty": "in_inner_parallel",
+      "source": "input connector",
+      "sourceProperty": "in_inner_parallel"
+    },
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_inner_parallel",
+      "source": "A",
+      "sourceProperty": "out_inner_parallel"
+    }
+  ],
+  "tasks": {
+    "A": {
+      "methods": [
+        {
+          "name": "inner",
+          "parameters": {
+            "links": [
+              {
+                "destination": "A",
+                "destinationProperty": "animal_type",
+                "source": "input connector",
+                "sourceProperty": "in_outer_parallel"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_outer_parallel",
+                "source": "A",
+                "sourceProperty": "animal_type"
+              },
+              {
+                "destination": "A",
+                "destinationProperty": "kitten_name",
+                "source": "input connector",
+                "sourceProperty": "in_inner_parallel"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_inner_parallel",
+                "source": "A",
+                "sourceProperty": "kitten_name"
+              }
+            ],
+            "tasks": {
+              "A": {
+                "methods": [
+                  {
+                    "name": "execute",
+                    "parameters": {
+                      "commandLine": [
+                        "./echo_command"
+                      ],
+                      "environment": {{ environment }},
+                      "user": "{{ user }}",
+                      "workingDirectory": "{{ workingDirectory }}"
+                    },
+                    "service": "shell-command"
+                  }
+                ],
+                "parallelBy": "kitten_name"
+              }
+            }
+          },
+          "service": "workflow"
+        }
+      ],
+      "parallelBy": "in_outer_parallel"
+    }
+  },
+  "inputs": {
+    "in_outer_parallel": [
+      "kittens",
+      "puppies"
+    ],
+    "in_inner_parallel": [
+      "Simba",
+      "Tabby",
+      "Emilio"
+    ]
+  }
+}

--- a/t/integration/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/test.t
+++ b/t/integration/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/test.t
@@ -1,0 +1,3 @@
+use Ptero::TestHelper qw(run_test);
+
+run_test(__FILE__);

--- a/t/integration/workflow_tests/parallel_by_dag/result.json
+++ b/t/integration/workflow_tests/parallel_by_dag/result.json
@@ -1,0 +1,6 @@
+{
+    "outputs": {
+        "out_constant": ["kittens", "kittens", "kittens"],
+        "out_parallel": ["Simba", "Tabby", "Emilio"]
+    }
+}

--- a/t/integration/workflow_tests/parallel_by_dag/submit.json
+++ b/t/integration/workflow_tests/parallel_by_dag/submit.json
@@ -1,0 +1,93 @@
+{
+  "links": [
+    {
+      "destination": "A",
+      "destinationProperty": "in_constant",
+      "source": "input connector",
+      "sourceProperty": "in_constant"
+    },
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_constant",
+      "source": "A",
+      "sourceProperty": "out_constant"
+    },
+    {
+      "destination": "A",
+      "destinationProperty": "in_parallel",
+      "source": "input connector",
+      "sourceProperty": "in_parallel"
+    },
+    {
+      "destination": "output connector",
+      "destinationProperty": "out_parallel",
+      "source": "A",
+      "sourceProperty": "out_parallel"
+    }
+  ],
+  "tasks": {
+    "A": {
+      "methods": [
+        {
+          "name": "inner",
+          "parameters": {
+            "links": [
+              {
+                "destination": "A",
+                "destinationProperty": "const_param",
+                "source": "input connector",
+                "sourceProperty": "in_constant"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_constant",
+                "source": "A",
+                "sourceProperty": "const_param"
+              },
+              {
+                "destination": "A",
+                "destinationProperty": "parallel_param",
+                "source": "input connector",
+                "sourceProperty": "in_parallel"
+              },
+              {
+                "destination": "output connector",
+                "destinationProperty": "out_parallel",
+                "source": "A",
+                "sourceProperty": "parallel_param"
+              }
+            ],
+            "tasks": {
+              "A": {
+                "methods": [
+                  {
+                    "name": "execute",
+                    "parameters": {
+                      "commandLine": [
+                        "./echo_command"
+                      ],
+                      "environment": {{ environment }},
+                      "user": "{{ user }}",
+                      "workingDirectory": "{{ workingDirectory }}"
+                    },
+                    "service": "shell-command"
+                  }
+                ]
+              }
+            }
+          },
+          "service": "workflow"
+        }
+      ],
+      "parallelBy": "in_parallel"
+    }
+  },
+  "inputs": {
+    "in_constant": "kittens",
+    "in_parallel": [
+      "Simba",
+      "Tabby",
+      "Emilio"
+    ]
+  }
+}

--- a/t/integration/workflow_tests/parallel_by_dag/test.t
+++ b/t/integration/workflow_tests/parallel_by_dag/test.t
@@ -1,0 +1,3 @@
+use Ptero::TestHelper qw(run_test);
+
+run_test(__FILE__);

--- a/t/integration/workflow_tests/parallel_by_dag_pass_through/README.md
+++ b/t/integration/workflow_tests/parallel_by_dag_pass_through/README.md
@@ -1,0 +1,2 @@
+This test ensures that links directly from the 'input connector' to the 'output
+connector' work as expected.

--- a/t/integration/workflow_tests/parallel_by_dag_pass_through/result.json
+++ b/t/integration/workflow_tests/parallel_by_dag_pass_through/result.json
@@ -1,0 +1,6 @@
+{
+    "outputs": {
+        "out_constant": ["kittens", "kittens", "kittens"],
+        "out_parallel": ["Simba", "Tabby", "Emilio"]
+    }
+}

--- a/t/integration/workflow_tests/parallel_by_dag_pass_through/submit.json
+++ b/t/integration/workflow_tests/parallel_by_dag_pass_through/submit.json
@@ -1,0 +1,116 @@
+{
+    "tasks": {
+        "Inner": {
+            "methods": [
+                {
+                    "name": "some_workflow",
+                    "parameters": {
+                        "tasks": {
+                            "michael": {
+                                "methods": [
+                                    {
+                                        "name": "execute",
+                                        "service": "shell-command",
+                                        "parameters": {
+                                            "commandLine": ["./echo_command"],
+                                            "user": "{{ user }}",
+                                            "workingDirectory": "{{ workingDirectory }}",
+                                            "environment": {{ environment }}
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        "links": [
+                            {
+                                "source": "input connector",
+                                "sourceProperty": "constant_param_in",
+                                "destination": "output connector",
+                                "destinationProperty": "constant_param_out"
+                            },
+                            {
+                                "source": "input connector",
+                                "sourceProperty": "constant_param_in",
+                                "destination": "michael",
+                                "destinationProperty": "constant_param_in"
+                            },
+                            {
+                                "source": "input connector",
+                                "sourceProperty": "parallel_param_in",
+                                "destination": "output connector",
+                                "destinationProperty": "parallel_param_out"
+                            },
+                            {
+                                "source": "michael",
+                                "sourceProperty": "constant_param_in",
+                                "destination": "output connector",
+                                "destinationProperty": "michael_param_out"
+                            }
+                        ]
+                    },
+                    "service": "workflow"
+                }
+            ],
+            "parallelBy": "parallel_param_in"
+        },
+        "A": {
+            "methods": [
+                {
+                    "name": "execute",
+                    "service": "shell-command",
+                    "parameters": {
+                        "commandLine": ["./echo_command"],
+                        "user": "{{ user }}",
+                        "workingDirectory": "{{ workingDirectory }}",
+                        "environment": {{ environment }}
+                    }
+                }
+            ]
+        }
+    },
+
+    "links": [
+        {
+            "source": "input connector",
+            "destination": "Inner",
+            "sourceProperty": "in_constant",
+            "destinationProperty": "constant_param_in"
+        },
+        {
+            "source": "Inner",
+            "destination": "A",
+            "sourceProperty": "constant_param_out",
+            "destinationProperty": "constant_param"
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "sourceProperty": "constant_param",
+            "destinationProperty": "out_constant"
+        },
+
+        {
+            "source": "input connector",
+            "destination": "Inner",
+            "sourceProperty": "in_parallel",
+            "destinationProperty": "parallel_param_in"
+        },
+        {
+            "source": "Inner",
+            "destination": "A",
+            "sourceProperty": "parallel_param_out",
+            "destinationProperty": "parallel_param"
+        },
+        {
+            "source": "A",
+            "destination": "output connector",
+            "sourceProperty": "parallel_param",
+            "destinationProperty": "out_parallel"
+        }
+    ],
+
+    "inputs": {
+        "in_constant": "kittens",
+        "in_parallel": ["Simba", "Tabby", "Emilio"]
+    }
+}

--- a/t/integration/workflow_tests/parallel_by_dag_pass_through/test.t
+++ b/t/integration/workflow_tests/parallel_by_dag_pass_through/test.t
@@ -1,0 +1,3 @@
+use Ptero::TestHelper qw(run_test);
+
+run_test(__FILE__);


### PR DESCRIPTION
This PR takes advantage of the fact that POSTing a workflow responds with a workflow resource in the body, and there is a new report 'workflow-status' that keeps us from having to fetch the entire workflow resource just to determine a workflow's status.