### PR TITLE
Add a Makefile.PL that makes use of our cpanfile

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,5 @@
+use inc::Module::Install;
+name 'Ptero';
+all_from 'lib/Ptero.pm';
+cpanfile;
+WriteAll;


### PR DESCRIPTION
With this Makfile and the presence of Module::Install::CPANfile, one can use cpanm and/or carton to install Ptero.pm:

    cpanm -n -L local https://api.github.com/repos/mcallaway/ptero-perl-sdk/tarball/mcallawa_makefile

Note that I use -n to skip tests. Some of the dependent modules fail their tests, but I think only due to whitespace changes, maybe something related to perl 5.21.