### PR TITLE
Fix link api

### DIFF
--- a/integration_tests/cancel_basic_workflow.t
+++ b/integration_tests/cancel_basic_workflow.t
@@ -27,21 +27,24 @@ sub create_echo_workflow {
     my $task_a = get_task($workflow, 'A');
     my $task_b = get_task($workflow, 'B');
 
-    $workflow->connect_input(
-        source_property => 'A_in',
+    $workflow->create_link(
         destination => $task_a,
-        destination_property => 'A_in',
+        data_flow => {
+            'A_in' => 'A_in',
+        },
     );
-    $workflow->link_tasks(
+    $workflow->create_link(
         source => $task_a,
         destination => $task_b,
-        source_property => 'A_in',
-        destination_property => 'A_in',
+        data_flow => {
+            'A_in' => 'A_in',
+        },
     );
-    $workflow->connect_output(
+    $workflow->create_link(
         source => $task_b,
-        source_property => 'A_in',
-        destination_property => 'A_out',
+        data_flow => {
+            'A_in' => 'A_out',
+        },
     );
 
     return $workflow;

--- a/integration_tests/post_basic_workflow.t
+++ b/integration_tests/post_basic_workflow.t
@@ -36,15 +36,17 @@ sub create_echo_workflow {
         name => 'A',
         methods => [$sc],
     );
-    $workflow->connect_input(
-        source_property => 'A_in',
+    $workflow->create_link(
         destination => $task,
-        destination_property => 'A_in',
+        data_flow => {
+            'A_in' => 'A_in',
+        },
     );
-    $workflow->connect_output(
+    $workflow->create_link(
         source => $task,
-        source_property => 'A_in',
-        destination_property => 'A_out',
+        data_flow => {
+            'A_in' => 'A_out',
+        },
     );
 
     return $workflow;

--- a/integration_tests/post_long_workflow.t
+++ b/integration_tests/post_long_workflow.t
@@ -107,15 +107,17 @@ sub create_echo_workflow {
             create_sleep_echo_command(),
         ],
     );
-    $workflow->connect_input(
-        source_property => 'easy_in',
+    $workflow->create_link(
         destination => $easy_street,
-        destination_property => 'easy_in',
+        data_flow => {
+            'easy_in' => 'easy_in',
+        },
     );
-    $workflow->connect_output(
+    $workflow->create_link(
         source => $easy_street,
-        source_property => 'easy_in',
-        destination_property => 'easy_out',
+        data_flow => {
+            'easy_in' => 'easy_out',
+        },
     );
 
     my $try_hard = $workflow->create_task(
@@ -130,12 +132,12 @@ sub create_echo_workflow {
             create_sleep_echo_command(),
         ],
     );
-    $workflow->connect_input(
+    $workflow->add_data_flow(
         source_property => 'try_in',
         destination => $try_hard,
         destination_property => 'try_in',
     );
-    $workflow->connect_output(
+    $workflow->add_data_flow(
         source => $try_hard,
         source_property => 'try_in',
         destination_property => 'try_out',

--- a/lib/Ptero/Builder/Workflow.pm
+++ b/lib/Ptero/Builder/Workflow.pm
@@ -190,7 +190,6 @@ sub validation_errors {
         _orphaned_task_errors
         _task_input_errors
         _task_output_errors
-        _multiple_link_target_errors
         _cycle_errors
     );
 
@@ -357,34 +356,6 @@ sub _task_output_errors {
                     );
                 }
             }
-        }
-    }
-
-    return @errors;
-}
-
-sub _multiple_link_target_errors {
-    my $self = shift;
-    my @errors;
-
-    my %destinations;
-
-    for my $link (@{$self->links}) {
-        for my $destination_property ($link->destination_properties) {
-            my $key = _encode_target($link->destination, $destination_property);
-            push @{$destinations{$key}}, $link;
-        }
-    }
-
-    while (my ($key, $links) = each %destinations) {
-        my @links = @$links;
-
-        if (@links > 1) {
-            push @errors, sprintf(
-                "Multiple links on Workflow (%s) target the same input_property:\n%s",
-                $self->name,
-                join(",\n", map { $_->to_string } @links),
-            );
         }
     }
 

--- a/lib/Ptero/Builder/Workflow.pm
+++ b/lib/Ptero/Builder/Workflow.pm
@@ -74,10 +74,10 @@ sub submit {
 sub create_task {
     my $self = shift;
     my $task= Ptero::Builder::Detail::Workflow::Task->new(@_);
-    return $self->_add_task($task);
+    return $self->add_task($task);
 }
 
-sub _add_task {
+sub add_task {
     my ($self, $task) = @_;
     $self->tasks([@{$self->tasks}, $task]);
     return $task;
@@ -484,7 +484,7 @@ sub from_hashref {
 
     while (my ($task_name, $task_hashref) = each %{$hashref->{parameters}->{tasks}}) {
         my $task_class = $class->task_class;
-        $self->_add_task($task_class->from_hashref(
+        $self->add_task($task_class->from_hashref(
             $task_hashref, $task_name));
     }
 

--- a/performance_tests/many_methods_workflow.t
+++ b/performance_tests/many_methods_workflow.t
@@ -53,12 +53,12 @@ sub create_workflow {
         name => 'A',
         methods => \@methods,
     );
-    $workflow->connect_input(
+    $workflow->add_data_flow(
         source_property => 'A_in',
         destination => $task,
         destination_property => 'A_in',
     );
-    $workflow->connect_output(
+    $workflow->add_data_flow(
         source => $task,
         source_property => 'A_in',
         destination_property => 'A_out',

--- a/performance_tests/many_tasks_workflow.t
+++ b/performance_tests/many_tasks_workflow.t
@@ -55,12 +55,12 @@ sub create_workflow {
             methods => [shell_command_method("method $i", "echo_test")],
         );
 
-        $workflow->connect_input(
+        $workflow->add_data_flow(
             source_property => 'A_in',
             destination => $task,
             destination_property => 'A_in',
         );
-        $workflow->connect_output(
+        $workflow->add_data_flow(
             source => $task,
             source_property => 'A_in',
             destination_property => "Task $i out",

--- a/performance_tests/nested_dags_workflow.t
+++ b/performance_tests/nested_dags_workflow.t
@@ -48,12 +48,12 @@ sub create_workflow {
             name => 'A',
             methods => [$method],
         );
-        $workflow->connect_input(
+        $workflow->add_data_flow(
             source_property => 'A_in',
             destination => $task,
             destination_property => 'A_in',
         );
-        $workflow->connect_output(
+        $workflow->add_data_flow(
             source => $task,
             source_property => 'A_in',
             destination_property => 'A_in',

--- a/t/Ptero/Builder/TestHelpers.pm
+++ b/t/Ptero/Builder/TestHelpers.pm
@@ -33,15 +33,17 @@ sub build_nested_workflow {
             succeeded => ['http://localhost:8080/example/task/succeeded', 'http://localhost:8080/congrats']
         },
     );
-    $workflow->connect_input(
-        source_property => 'A_in',
+    $workflow->create_link(
         destination => $task,
-        destination_property => 'A_in',
+        data_flow => {
+            'A_in' => 'A_in',
+        }
     );
-    $workflow->connect_output(
+    $workflow->create_link(
         source => $task,
-        source_property => 'A_out',
-        destination_property => 'A_out',
+        data_flow => {
+            'A_out' => 'A_out',
+        }
     );
     $workflow->webhooks( {
         scheduled => 'http://localhost:8080/example/outer/scheduled',
@@ -78,15 +80,17 @@ sub build_basic_workflow {
             succeeded => ['http://localhost:8080/example/task/succeeded', 'http://localhost:8080/congrats']
         },
     );
-    $workflow->connect_input(
-        source_property => 'A_in',
+    $workflow->create_link(
         destination => $task,
-        destination_property => 'A_in',
+        data_flow => {
+            'A_in' => 'A_in',
+        }
     );
-    $workflow->connect_output(
+    $workflow->create_link(
         source => $task,
-        source_property => 'A_out',
-        destination_property => 'A_out',
+        data_flow => {
+            'A_out' => 'A_out',
+        }
     );
     $workflow->webhooks( {
         scheduled => 'http://localhost:8080/example/workflow/scheduled',

--- a/t/Ptero/Builder/Workflow-validation-errors.t
+++ b/t/Ptero/Builder/Workflow-validation-errors.t
@@ -28,7 +28,7 @@ use Ptero::Builder::TestHelpers qw(
 
 {
     my $workflow = build_basic_workflow('missing-task-names');
-    $workflow->connect_input(
+    $workflow->add_data_flow(
         source_property => 'C_in',
         destination => 'C',
         destination_property => 'C_in',
@@ -46,7 +46,7 @@ use Ptero::Builder::TestHelpers qw(
 
     # create an additional manditory input
     my $task = $workflow->task_named('A');
-    $task->methods->[0]->connect_input(
+    $task->methods->[0]->add_data_flow(
         source_property => 'A_in_two',
         destination => 'A',
         destination_property => 'A_in_two',
@@ -60,14 +60,14 @@ use Ptero::Builder::TestHelpers qw(
     my $workflow = build_nested_workflow('invalid-output');
 
     my $inner_workflow = $workflow->task_named('A')->methods->[0];
-    $inner_workflow->connect_output(
+    $inner_workflow->add_data_flow(
         source => 'A',
         source_property => 'A_out_two',
         destination_property => 'A_out_two',
     );
     is_deeply([$workflow->validation_errors], [], 'no validation errors (task has unknown io properties)');
 
-    $workflow->connect_output(
+    $workflow->add_data_flow(
         source => 'A',
         source_property => 'A_out_missing',
         destination_property => 'A_out_missing',
@@ -93,13 +93,13 @@ use Ptero::Builder::TestHelpers qw(
 {
     my $workflow = build_nested_workflow('cycle');
     create_basic_task($workflow, 'B');
-    $workflow->link_tasks(
+    $workflow->add_data_flow(
         source => 'A',
         source_property => 'A_out',
         destination => 'B',
         destination_property => 'B_in',
     );
-    $workflow->link_tasks(
+    $workflow->add_data_flow(
         source => 'B',
         source_property => 'B_out',
         destination => 'A',

--- a/t/Ptero/Builder/Workflow-validation-errors.t
+++ b/t/Ptero/Builder/Workflow-validation-errors.t
@@ -78,19 +78,6 @@ use Ptero::Builder::TestHelpers qw(
 }
 
 {
-    my $workflow = build_basic_workflow('multi-link-target');
-    $workflow->connect_input(
-        source_property => 'A_in_two',
-        destination => 'A',
-        destination_property => 'A_in',
-    );
-    is_deeply([$workflow->validation_errors], [
-            qq(Multiple links on Workflow (multi-link-target) target the same input_property:\nPtero::Builder::Detail::Workflow::Link(source => "input connector", destination => "A", data_flow => { A_in => ["A_in"] }),\nPtero::Builder::Detail::Workflow::Link(source => "input connector", destination => "A", data_flow => { A_in_two => ["A_in"] })),
-        ], 'multi link target');
-
-}
-
-{
     my $workflow = build_nested_workflow('cycle');
     create_basic_task($workflow, 'B');
     $workflow->add_data_flow(

--- a/t/Ptero/Builder/Workflow.t
+++ b/t/Ptero/Builder/Workflow.t
@@ -29,12 +29,12 @@ use_ok('Ptero::Builder::ShellCommand');
 {
     my $workflow = build_basic_workflow('basic');
     create_basic_task($workflow, 'B');
-    $workflow->connect_input(
+    $workflow->add_data_flow(
         source_property => 'B_in',
         destination => 'B',
         destination_property => 'B_in',
     );
-    $workflow->link_tasks(
+    $workflow->add_data_flow(
         source => 'B',
         source_property => 'B_out',
         destination => 'A',


### PR DESCRIPTION
The previous api made it impossible to add more than one data-flow to a link unless it was defined on the link in the first place.  This makes it possible to build up the data-flows incrementally.