### PR TITLE
Changes to ptero-view

### DIFF
--- a/integration_tests/workflow_tests/control_flow/workflow-view.txt
+++ b/integration_tests/workflow_tests/control_flow/workflow-view.txt
@@ -1,6 +1,6 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-07-22T22:11:17      00:00:03           OPWcH0uSTPiLsc6L72DRpA
-           Task  succeeded  2015-07-22T22:11:18      00:00:01           A 
-   ShellCommand  succeeded  2015-07-22T22:11:19      00:00:00           . execute
-           Task  succeeded  2015-07-22T22:11:19      00:00:01           B 
-   ShellCommand  succeeded  2015-07-22T22:11:20      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-07-22T22:11:17      00:00:03  OPWcH0uSTPiLsc6L72DRpA
+           Task  succeeded  2015-07-22T22:11:18      00:00:01  A 
+   ShellCommand  succeeded  2015-07-22T22:11:19      00:00:00  . execute
+           Task  succeeded  2015-07-22T22:11:19      00:00:01  B 
+   ShellCommand  succeeded  2015-07-22T22:11:20      00:00:00  . execute

--- a/integration_tests/workflow_tests/n_shaped/workflow-view.txt
+++ b/integration_tests/workflow_tests/n_shaped/workflow-view.txt
@@ -1,10 +1,10 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:38:25      00:00:05           ECsuTiLYTdGd1ZLB5EkbsQ
-           Task  succeeded  2015-05-28T20:38:26      00:00:02           A 
-   ShellCommand  succeeded  2015-05-28T20:38:27      00:00:01           . execute
-           Task  succeeded  2015-05-28T20:38:26      00:00:02           B 
-   ShellCommand  succeeded  2015-05-28T20:38:28      00:00:00           . execute
-           Task  succeeded  2015-05-28T20:38:28      00:00:02           C 
-   ShellCommand  succeeded  2015-05-28T20:38:29      00:00:00           . execute
-           Task  succeeded  2015-05-28T20:38:28      00:00:02           D 
-   ShellCommand  succeeded  2015-05-28T20:38:29      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:38:25      00:00:05  ECsuTiLYTdGd1ZLB5EkbsQ
+           Task  succeeded  2015-05-28T20:38:26      00:00:02  A 
+   ShellCommand  succeeded  2015-05-28T20:38:27      00:00:01  . execute
+           Task  succeeded  2015-05-28T20:38:26      00:00:02  B 
+   ShellCommand  succeeded  2015-05-28T20:38:28      00:00:00  . execute
+           Task  succeeded  2015-05-28T20:38:28      00:00:02  C 
+   ShellCommand  succeeded  2015-05-28T20:38:29      00:00:00  . execute
+           Task  succeeded  2015-05-28T20:38:28      00:00:02  D 
+   ShellCommand  succeeded  2015-05-28T20:38:29      00:00:00  . execute

--- a/integration_tests/workflow_tests/n_shaped_with_block/workflow-view.txt
+++ b/integration_tests/workflow_tests/n_shaped_with_block/workflow-view.txt
@@ -1,12 +1,12 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-07-25T04:34:45      00:00:05           WxIc2saZR5WS8vrNPPI6Dg
-           Task  succeeded  2015-07-25T04:34:46      00:00:02           A 
-   ShellCommand  succeeded  2015-07-25T04:34:47      00:00:00           . execute
-           Task  succeeded  2015-07-25T04:34:46      00:00:02           B 
-   ShellCommand  succeeded  2015-07-25T04:34:47      00:00:00           . execute
-           Task  succeeded  2015-07-25T04:34:48      00:00:01           C 
-   ShellCommand  succeeded  2015-07-25T04:34:49      00:00:00           . execute
-           Task  succeeded  2015-07-25T04:34:48      00:00:01           D 
-   ShellCommand  succeeded  2015-07-25T04:34:49      00:00:00           . execute
-           Task  succeeded  2015-07-25T04:34:50      00:00:00           Block 
-                 succeeded  2015-07-25T04:34:50      00:00:00           . blocker
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-07-25T04:34:45      00:00:05  WxIc2saZR5WS8vrNPPI6Dg
+           Task  succeeded  2015-07-25T04:34:46      00:00:02  A 
+   ShellCommand  succeeded  2015-07-25T04:34:47      00:00:00  . execute
+           Task  succeeded  2015-07-25T04:34:46      00:00:02  B 
+   ShellCommand  succeeded  2015-07-25T04:34:47      00:00:00  . execute
+           Task  succeeded  2015-07-25T04:34:48      00:00:01  C 
+   ShellCommand  succeeded  2015-07-25T04:34:49      00:00:00  . execute
+           Task  succeeded  2015-07-25T04:34:48      00:00:01  D 
+   ShellCommand  succeeded  2015-07-25T04:34:49      00:00:00  . execute
+           Task  succeeded  2015-07-25T04:34:50      00:00:00  Block 
+                 succeeded  2015-07-25T04:34:50      00:00:00  . blocker

--- a/integration_tests/workflow_tests/nested/workflow-view.txt
+++ b/integration_tests/workflow_tests/nested/workflow-view.txt
@@ -1,10 +1,10 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:38:31      00:00:05           G1KjUvUsTHuMie3CT1W2sw
-           Task  succeeded  2015-05-28T20:38:32      00:00:02           A 
-   ShellCommand  succeeded  2015-05-28T20:38:33      00:00:00           . execute
-           Task  succeeded  2015-05-28T20:38:32      00:00:03           Inner 
-            DAG  succeeded  2015-05-28T20:38:33      00:00:02           . some_workflow
-           Task  succeeded  2015-05-28T20:38:33      00:00:02           . . B 
-   ShellCommand  succeeded  2015-05-28T20:38:34      00:00:00           . . . execute
-           Task  succeeded  2015-05-28T20:38:35      00:00:01           C 
-   ShellCommand  succeeded  2015-05-28T20:38:36      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:38:31      00:00:05  G1KjUvUsTHuMie3CT1W2sw
+           Task  succeeded  2015-05-28T20:38:32      00:00:02  A 
+   ShellCommand  succeeded  2015-05-28T20:38:33      00:00:00  . execute
+           Task  succeeded  2015-05-28T20:38:32      00:00:03  Inner 
+            DAG  succeeded  2015-05-28T20:38:33      00:00:02  . some_workflow
+           Task  succeeded  2015-05-28T20:38:33      00:00:02  . . B 
+   ShellCommand  succeeded  2015-05-28T20:38:34      00:00:00  . . . execute
+           Task  succeeded  2015-05-28T20:38:35      00:00:01  C 
+   ShellCommand  succeeded  2015-05-28T20:38:36      00:00:00  . execute

--- a/integration_tests/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/workflow-view.txt
+++ b/integration_tests/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/workflow-view.txt
@@ -1,25 +1,33 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:38:37      00:00:12           wzzqRbAtQpe77mRJQrtJzg
-           Task  succeeded  2015-05-28T20:38:39      00:00:09           A parallel-by: in_outer_parallel
-            DAG  succeeded  2015-05-28T20:38:40      00:00:08  0        . inner
-           Task  succeeded  2015-05-28T20:38:40      00:00:08  0        . . Inner parallel-by: kitten_name_in
-            DAG  succeeded  2015-05-28T20:38:41      00:00:06  0, 0     . . . some_workflow
-           Task  succeeded  2015-05-28T20:38:42      00:00:04  0, 0     . . . . A 
-   ShellCommand  succeeded  2015-05-28T20:38:46      00:00:00  0, 0     . . . . . execute
-            DAG  succeeded  2015-05-28T20:38:41      00:00:07  0, 1     . . . some_workflow
-           Task  succeeded  2015-05-28T20:38:42      00:00:05  0, 1     . . . . A 
-   ShellCommand  succeeded  2015-05-28T20:38:46      00:00:01  0, 1     . . . . . execute
-            DAG  succeeded  2015-05-28T20:38:41      00:00:05  0, 2     . . . some_workflow
-           Task  succeeded  2015-05-28T20:38:42      00:00:04  0, 2     . . . . A 
-   ShellCommand  succeeded  2015-05-28T20:38:43      00:00:02  0, 2     . . . . . execute
-            DAG  succeeded  2015-05-28T20:38:40      00:00:08  1        . inner
-           Task  succeeded  2015-05-28T20:38:40      00:00:08  1        . . Inner parallel-by: kitten_name_in
-            DAG  succeeded  2015-05-28T20:38:41      00:00:06  1, 0     . . . some_workflow
-           Task  succeeded  2015-05-28T20:38:42      00:00:04  1, 0     . . . . A 
-   ShellCommand  succeeded  2015-05-28T20:38:45      00:00:01  1, 0     . . . . . execute
-            DAG  succeeded  2015-05-28T20:38:41      00:00:07  1, 1     . . . some_workflow
-           Task  succeeded  2015-05-28T20:38:42      00:00:05  1, 1     . . . . A 
-   ShellCommand  succeeded  2015-05-28T20:38:47      00:00:00  1, 1     . . . . . execute
-            DAG  succeeded  2015-05-28T20:38:41      00:00:06  1, 2     . . . some_workflow
-           Task  succeeded  2015-05-28T20:38:42      00:00:05  1, 2     . . . . A 
-   ShellCommand  succeeded  2015-05-28T20:38:46      00:00:01  1, 2     . . . . . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:38:37      00:00:12  wzzqRbAtQpe77mRJQrtJzg
+           Task  succeeded  2015-05-28T20:38:39      00:00:09  A [parallel-by: in_outer_parallel]
+           Task  succeeded  2015-05-28T20:38:39      00:00:09  . A [0]
+            DAG  succeeded  2015-05-28T20:38:40      00:00:08  . . inner
+           Task  succeeded  2015-05-28T20:38:40      00:00:08  . . . Inner [parallel-by: kitten_name_in]
+           Task  succeeded  2015-05-28T20:38:40      00:00:07  . . . . Inner [0, 0]
+            DAG  succeeded  2015-05-28T20:38:41      00:00:06  . . . . . some_workflow
+           Task  succeeded  2015-05-28T20:38:42      00:00:04  . . . . . . A 
+   ShellCommand  succeeded  2015-05-28T20:38:46      00:00:00  . . . . . . . execute
+           Task  succeeded  2015-05-28T20:38:40      00:00:08  . . . . Inner [0, 1]
+            DAG  succeeded  2015-05-28T20:38:41      00:00:07  . . . . . some_workflow
+           Task  succeeded  2015-05-28T20:38:42      00:00:05  . . . . . . A 
+   ShellCommand  succeeded  2015-05-28T20:38:46      00:00:01  . . . . . . . execute
+           Task  succeeded  2015-05-28T20:38:40      00:00:06  . . . . Inner [0, 2]
+            DAG  succeeded  2015-05-28T20:38:41      00:00:05  . . . . . some_workflow
+           Task  succeeded  2015-05-28T20:38:42      00:00:04  . . . . . . A 
+   ShellCommand  succeeded  2015-05-28T20:38:43      00:00:02  . . . . . . . execute
+           Task  succeeded  2015-05-28T20:38:39      00:00:09  . A [1]
+            DAG  succeeded  2015-05-28T20:38:40      00:00:08  . . inner
+           Task  succeeded  2015-05-28T20:38:40      00:00:08  . . . Inner [parallel-by: kitten_name_in]
+           Task  succeeded  2015-05-28T20:38:40      00:00:07  . . . . Inner [1, 0]
+            DAG  succeeded  2015-05-28T20:38:41      00:00:06  . . . . . some_workflow
+           Task  succeeded  2015-05-28T20:38:42      00:00:04  . . . . . . A 
+   ShellCommand  succeeded  2015-05-28T20:38:45      00:00:01  . . . . . . . execute
+           Task  succeeded  2015-05-28T20:38:40      00:00:08  . . . . Inner [1, 1]
+            DAG  succeeded  2015-05-28T20:38:41      00:00:07  . . . . . some_workflow
+           Task  succeeded  2015-05-28T20:38:42      00:00:05  . . . . . . A 
+   ShellCommand  succeeded  2015-05-28T20:38:47      00:00:00  . . . . . . . execute
+           Task  succeeded  2015-05-28T20:38:40      00:00:07  . . . . Inner [1, 2]
+            DAG  succeeded  2015-05-28T20:38:41      00:00:06  . . . . . some_workflow
+           Task  succeeded  2015-05-28T20:38:42      00:00:05  . . . . . . A 
+   ShellCommand  succeeded  2015-05-28T20:38:46      00:00:01  . . . . . . . execute

--- a/integration_tests/workflow_tests/nested_parallel_by_operation_matrix_inputs/workflow-view.txt
+++ b/integration_tests/workflow_tests/nested_parallel_by_operation_matrix_inputs/workflow-view.txt
@@ -1,12 +1,19 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:38:50      00:00:08           kUprIXsmRoqD8m6FtKerWA
-           Task  succeeded  2015-05-28T20:38:51      00:00:06           A parallel-by: in_matrix
-            DAG  succeeded  2015-05-28T20:38:52      00:00:05  0        . inner
-           Task  succeeded  2015-05-28T20:38:52      00:00:05  0        . . A parallel-by: name
-   ShellCommand  succeeded  2015-05-28T20:38:56      00:00:00  0, 1     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:38:56      00:00:00  0, 0     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:38:55      00:00:01  0, 2     . . . execute
-            DAG  succeeded  2015-05-28T20:38:52      00:00:05  1        . inner
-           Task  succeeded  2015-05-28T20:38:52      00:00:05  1        . . A parallel-by: name
-   ShellCommand  succeeded  2015-05-28T20:38:54      00:00:02  1, 0     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:38:56      00:00:00  1, 1     . . . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:38:50      00:00:08  kUprIXsmRoqD8m6FtKerWA
+           Task  succeeded  2015-05-28T20:38:51      00:00:06  A [parallel-by: in_matrix]
+           Task  succeeded  2015-05-28T20:38:52      00:00:05  . A [0]
+            DAG  succeeded  2015-05-28T20:38:52      00:00:05  . . inner
+           Task  succeeded  2015-05-28T20:38:52      00:00:05  . . . A [parallel-by: name]
+           Task  succeeded  2015-05-28T20:38:53      00:00:03  . . . . A [0, 0]
+   ShellCommand  succeeded  2015-05-28T20:38:56      00:00:00  . . . . . execute
+           Task  succeeded  2015-05-28T20:38:53      00:00:04  . . . . A [0, 1]
+   ShellCommand  succeeded  2015-05-28T20:38:56      00:00:00  . . . . . execute
+           Task  succeeded  2015-05-28T20:38:52      00:00:04  . . . . A [0, 2]
+   ShellCommand  succeeded  2015-05-28T20:38:55      00:00:01  . . . . . execute
+           Task  succeeded  2015-05-28T20:38:52      00:00:05  . A [1]
+            DAG  succeeded  2015-05-28T20:38:52      00:00:05  . . inner
+           Task  succeeded  2015-05-28T20:38:52      00:00:05  . . . A [parallel-by: name]
+           Task  succeeded  2015-05-28T20:38:52      00:00:04  . . . . A [1, 0]
+   ShellCommand  succeeded  2015-05-28T20:38:54      00:00:02  . . . . . execute
+           Task  succeeded  2015-05-28T20:38:53      00:00:03  . . . . A [1, 1]
+   ShellCommand  succeeded  2015-05-28T20:38:56      00:00:00  . . . . . execute

--- a/integration_tests/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/workflow-view.txt
+++ b/integration_tests/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/workflow-view.txt
@@ -1,13 +1,21 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:38:59      00:00:08           1wN1h4AtTwyUryBum6Zqrg
-           Task  succeeded  2015-05-28T20:39:00      00:00:07           A parallel-by: in_outer_parallel
-            DAG  succeeded  2015-05-28T20:39:01      00:00:06  0        . inner
-           Task  succeeded  2015-05-28T20:39:01      00:00:05  0        . . A parallel-by: kitten_name
-   ShellCommand  succeeded  2015-05-28T20:39:02      00:00:03  0, 1     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:39:05      00:00:01  0, 0     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:39:05      00:00:00  0, 2     . . . execute
-            DAG  succeeded  2015-05-28T20:39:01      00:00:06  1        . inner
-           Task  succeeded  2015-05-28T20:39:01      00:00:05  1        . . A parallel-by: kitten_name
-   ShellCommand  succeeded  2015-05-28T20:39:06      00:00:00  1, 2     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:39:06      00:00:00  1, 0     . . . execute
-   ShellCommand  succeeded  2015-05-28T20:39:05      00:00:00  1, 1     . . . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:38:59      00:00:08  1wN1h4AtTwyUryBum6Zqrg
+           Task  succeeded  2015-05-28T20:39:00      00:00:07  A [parallel-by: in_outer_parallel]
+           Task  succeeded  2015-05-28T20:39:00      00:00:07  . A [0]
+            DAG  succeeded  2015-05-28T20:39:01      00:00:06  . . inner
+           Task  succeeded  2015-05-28T20:39:01      00:00:05  . . . A [parallel-by: kitten_name]
+           Task  succeeded  2015-05-28T20:39:01      00:00:05  . . . . A [0, 0]
+   ShellCommand  succeeded  2015-05-28T20:39:05      00:00:01  . . . . . execute
+           Task  succeeded  2015-05-28T20:39:01      00:00:04  . . . . A [0, 1]
+   ShellCommand  succeeded  2015-05-28T20:39:02      00:00:03  . . . . . execute
+           Task  succeeded  2015-05-28T20:39:01      00:00:05  . . . . A [0, 2]
+   ShellCommand  succeeded  2015-05-28T20:39:05      00:00:00  . . . . . execute
+           Task  succeeded  2015-05-28T20:39:01      00:00:06  . A [1]
+            DAG  succeeded  2015-05-28T20:39:01      00:00:06  . . inner
+           Task  succeeded  2015-05-28T20:39:01      00:00:05  . . . A [parallel-by: kitten_name]
+           Task  succeeded  2015-05-28T20:39:01      00:00:05  . . . . A [1, 0]
+   ShellCommand  succeeded  2015-05-28T20:39:06      00:00:00  . . . . . execute
+           Task  succeeded  2015-05-28T20:39:02      00:00:04  . . . . A [1, 1]
+   ShellCommand  succeeded  2015-05-28T20:39:05      00:00:00  . . . . . execute
+           Task  succeeded  2015-05-28T20:39:02      00:00:04  . . . . A [1, 2]
+   ShellCommand  succeeded  2015-05-28T20:39:06      00:00:00  . . . . . execute

--- a/integration_tests/workflow_tests/parallel_by_dag/workflow-view.txt
+++ b/integration_tests/workflow_tests/parallel_by_dag/workflow-view.txt
@@ -1,12 +1,15 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:08      00:00:06           QaWMowlgSaap5w6SjzteNQ
-           Task  succeeded  2015-05-28T20:39:09      00:00:04           A parallel-by: in_parallel
-            DAG  succeeded  2015-05-28T20:39:10      00:00:03  0        . inner
-           Task  succeeded  2015-05-28T20:39:10      00:00:02  0        . . A 
-   ShellCommand  succeeded  2015-05-28T20:39:12      00:00:00  0        . . . execute
-            DAG  succeeded  2015-05-28T20:39:10      00:00:03  2        . inner
-           Task  succeeded  2015-05-28T20:39:10      00:00:03  2        . . A 
-   ShellCommand  succeeded  2015-05-28T20:39:12      00:00:01  2        . . . execute
-            DAG  succeeded  2015-05-28T20:39:10      00:00:03  1        . inner
-           Task  succeeded  2015-05-28T20:39:10      00:00:03  1        . . A 
-   ShellCommand  succeeded  2015-05-28T20:39:12      00:00:00  1        . . . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:08      00:00:06  QaWMowlgSaap5w6SjzteNQ
+           Task  succeeded  2015-05-28T20:39:09      00:00:04  A [parallel-by: in_parallel]
+           Task  succeeded  2015-05-28T20:39:09      00:00:04  . A [0]
+            DAG  succeeded  2015-05-28T20:39:10      00:00:03  . . inner
+           Task  succeeded  2015-05-28T20:39:10      00:00:02  . . . A 
+   ShellCommand  succeeded  2015-05-28T20:39:12      00:00:00  . . . . execute
+           Task  succeeded  2015-05-28T20:39:09      00:00:04  . A [1]
+            DAG  succeeded  2015-05-28T20:39:10      00:00:03  . . inner
+           Task  succeeded  2015-05-28T20:39:10      00:00:03  . . . A 
+   ShellCommand  succeeded  2015-05-28T20:39:12      00:00:00  . . . . execute
+           Task  succeeded  2015-05-28T20:39:10      00:00:03  . A [2]
+            DAG  succeeded  2015-05-28T20:39:10      00:00:03  . . inner
+           Task  succeeded  2015-05-28T20:39:10      00:00:03  . . . A 
+   ShellCommand  succeeded  2015-05-28T20:39:12      00:00:01  . . . . execute

--- a/integration_tests/workflow_tests/parallel_by_dag_pass_through/workflow-view.txt
+++ b/integration_tests/workflow_tests/parallel_by_dag_pass_through/workflow-view.txt
@@ -1,14 +1,17 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:15      00:00:07           iXDuo3dET6SlLMMQlCvJ7A
-           Task  succeeded  2015-05-28T20:39:16      00:00:04           Inner parallel-by: parallel_param_in
-            DAG  succeeded  2015-05-28T20:39:17      00:00:03  0        . some_workflow
-           Task  succeeded  2015-05-28T20:39:17      00:00:03  0        . . michael 
-   ShellCommand  succeeded  2015-05-28T20:39:19      00:00:00  0        . . . execute
-            DAG  succeeded  2015-05-28T20:39:17      00:00:03  2        . some_workflow
-           Task  succeeded  2015-05-28T20:39:17      00:00:03  2        . . michael 
-   ShellCommand  succeeded  2015-05-28T20:39:19      00:00:00  2        . . . execute
-            DAG  succeeded  2015-05-28T20:39:17      00:00:03  1        . some_workflow
-           Task  succeeded  2015-05-28T20:39:17      00:00:03  1        . . michael 
-   ShellCommand  succeeded  2015-05-28T20:39:19      00:00:01  1        . . . execute
-           Task  succeeded  2015-05-28T20:39:20      00:00:01           A 
-   ShellCommand  succeeded  2015-05-28T20:39:21      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:15      00:00:07  iXDuo3dET6SlLMMQlCvJ7A
+           Task  succeeded  2015-05-28T20:39:16      00:00:04  Inner [parallel-by: parallel_param_in]
+           Task  succeeded  2015-05-28T20:39:16      00:00:04  . Inner [0]
+            DAG  succeeded  2015-05-28T20:39:17      00:00:03  . . some_workflow
+           Task  succeeded  2015-05-28T20:39:17      00:00:03  . . . michael 
+   ShellCommand  succeeded  2015-05-28T20:39:19      00:00:00  . . . . execute
+           Task  succeeded  2015-05-28T20:39:17      00:00:03  . Inner [1]
+            DAG  succeeded  2015-05-28T20:39:17      00:00:03  . . some_workflow
+           Task  succeeded  2015-05-28T20:39:17      00:00:03  . . . michael 
+   ShellCommand  succeeded  2015-05-28T20:39:19      00:00:01  . . . . execute
+           Task  succeeded  2015-05-28T20:39:17      00:00:03  . Inner [2]
+            DAG  succeeded  2015-05-28T20:39:17      00:00:03  . . some_workflow
+           Task  succeeded  2015-05-28T20:39:17      00:00:03  . . . michael 
+   ShellCommand  succeeded  2015-05-28T20:39:19      00:00:00  . . . . execute
+           Task  succeeded  2015-05-28T20:39:20      00:00:01  A 
+   ShellCommand  succeeded  2015-05-28T20:39:21      00:00:00  . execute

--- a/integration_tests/workflow_tests/parallel_by_nested_dag/workflow-view.txt
+++ b/integration_tests/workflow_tests/parallel_by_nested_dag/workflow-view.txt
@@ -1,12 +1,15 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:23      00:00:06           EM1n0seaR36F_IdqgiDhIQ
-           Task  succeeded  2015-05-28T20:39:24      00:00:04           Inner parallel-by: parallel_param_in
-            DAG  succeeded  2015-05-28T20:39:25      00:00:03  0        . some_workflow
-           Task  succeeded  2015-05-28T20:39:25      00:00:02  0        . . A 
-   ShellCommand  succeeded  2015-05-28T20:39:27      00:00:00  0        . . . execute
-            DAG  succeeded  2015-05-28T20:39:25      00:00:03  2        . some_workflow
-           Task  succeeded  2015-05-28T20:39:25      00:00:03  2        . . A 
-   ShellCommand  succeeded  2015-05-28T20:39:27      00:00:00  2        . . . execute
-            DAG  succeeded  2015-05-28T20:39:25      00:00:03  1        . some_workflow
-           Task  succeeded  2015-05-28T20:39:25      00:00:03  1        . . A 
-   ShellCommand  succeeded  2015-05-28T20:39:27      00:00:01  1        . . . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:23      00:00:06  EM1n0seaR36F_IdqgiDhIQ
+           Task  succeeded  2015-05-28T20:39:24      00:00:04  Inner [parallel-by: parallel_param_in]
+           Task  succeeded  2015-05-28T20:39:24      00:00:04  . Inner [0]
+            DAG  succeeded  2015-05-28T20:39:25      00:00:03  . . some_workflow
+           Task  succeeded  2015-05-28T20:39:25      00:00:02  . . . A 
+   ShellCommand  succeeded  2015-05-28T20:39:27      00:00:00  . . . . execute
+           Task  succeeded  2015-05-28T20:39:25      00:00:03  . Inner [1]
+            DAG  succeeded  2015-05-28T20:39:25      00:00:03  . . some_workflow
+           Task  succeeded  2015-05-28T20:39:25      00:00:03  . . . A 
+   ShellCommand  succeeded  2015-05-28T20:39:27      00:00:01  . . . . execute
+           Task  succeeded  2015-05-28T20:39:24      00:00:04  . Inner [2]
+            DAG  succeeded  2015-05-28T20:39:25      00:00:03  . . some_workflow
+           Task  succeeded  2015-05-28T20:39:25      00:00:03  . . . A 
+   ShellCommand  succeeded  2015-05-28T20:39:27      00:00:00  . . . . execute

--- a/integration_tests/workflow_tests/parallel_by_operation/workflow-view.txt
+++ b/integration_tests/workflow_tests/parallel_by_operation/workflow-view.txt
@@ -1,6 +1,9 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:30      00:00:04           YciZKHM1SC6gkZXLddQ8pA
-           Task  succeeded  2015-05-28T20:39:31      00:00:03           A parallel-by: parallel_param
-   ShellCommand  succeeded  2015-05-28T20:39:33      00:00:00  0        . execute
-   ShellCommand  succeeded  2015-05-28T20:39:32      00:00:01  2        . execute
-   ShellCommand  succeeded  2015-05-28T20:39:33      00:00:00  1        . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:30      00:00:04  YciZKHM1SC6gkZXLddQ8pA
+           Task  succeeded  2015-05-28T20:39:31      00:00:03  A [parallel-by: parallel_param]
+           Task  succeeded  2015-05-28T20:39:31      00:00:03  . A [0]
+   ShellCommand  succeeded  2015-05-28T20:39:33      00:00:00  . . execute
+           Task  succeeded  2015-05-28T20:39:31      00:00:02  . A [1]
+   ShellCommand  succeeded  2015-05-28T20:39:33      00:00:00  . . execute
+           Task  succeeded  2015-05-28T20:39:31      00:00:02  . A [2]
+   ShellCommand  succeeded  2015-05-28T20:39:32      00:00:01  . . execute

--- a/integration_tests/workflow_tests/sequential_parallel_by/workflow-view.txt
+++ b/integration_tests/workflow_tests/sequential_parallel_by/workflow-view.txt
@@ -1,10 +1,16 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:35      00:00:07           sxu_SGVmQbGzvVnVbJwoNw
-           Task  succeeded  2015-05-28T20:39:36      00:00:03           A parallel-by: parallel_param
-   ShellCommand  succeeded  2015-05-28T20:39:37      00:00:01  0        . execute
-   ShellCommand  succeeded  2015-05-28T20:39:38      00:00:00  2        . execute
-   ShellCommand  succeeded  2015-05-28T20:39:38      00:00:01  1        . execute
-           Task  succeeded  2015-05-28T20:39:39      00:00:03           B parallel-by: parallel_param
-   ShellCommand  succeeded  2015-05-28T20:39:41      00:00:00  2        . execute
-   ShellCommand  succeeded  2015-05-28T20:39:41      00:00:00  0        . execute
-   ShellCommand  succeeded  2015-05-28T20:39:41      00:00:00  1        . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:35      00:00:07  sxu_SGVmQbGzvVnVbJwoNw
+           Task  succeeded  2015-05-28T20:39:36      00:00:03  A [parallel-by: parallel_param]
+           Task  succeeded  2015-05-28T20:39:36      00:00:02  . A [0]
+   ShellCommand  succeeded  2015-05-28T20:39:37      00:00:01  . . execute
+           Task  succeeded  2015-05-28T20:39:36      00:00:03  . A [1]
+   ShellCommand  succeeded  2015-05-28T20:39:38      00:00:01  . . execute
+           Task  succeeded  2015-05-28T20:39:36      00:00:02  . A [2]
+   ShellCommand  succeeded  2015-05-28T20:39:38      00:00:00  . . execute
+           Task  succeeded  2015-05-28T20:39:39      00:00:03  B [parallel-by: parallel_param]
+           Task  succeeded  2015-05-28T20:39:39      00:00:02  . B [0]
+   ShellCommand  succeeded  2015-05-28T20:39:41      00:00:00  . . execute
+           Task  succeeded  2015-05-28T20:39:39      00:00:02  . B [1]
+   ShellCommand  succeeded  2015-05-28T20:39:41      00:00:00  . . execute
+           Task  succeeded  2015-05-28T20:39:39      00:00:02  . B [2]
+   ShellCommand  succeeded  2015-05-28T20:39:41      00:00:00  . . execute

--- a/integration_tests/workflow_tests/serial/workflow-view.txt
+++ b/integration_tests/workflow_tests/serial/workflow-view.txt
@@ -1,8 +1,8 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:43      00:00:04           N_PbIYhGR--4f8XFz1RZVA
-           Task  succeeded  2015-05-28T20:39:44      00:00:01           A 
-   ShellCommand  succeeded  2015-05-28T20:39:44      00:00:01           . execute
-           Task  succeeded  2015-05-28T20:39:45      00:00:01           B 
-   ShellCommand  succeeded  2015-05-28T20:39:45      00:00:00           . execute
-           Task  succeeded  2015-05-28T20:39:46      00:00:00           C 
-   ShellCommand  succeeded  2015-05-28T20:39:46      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:43      00:00:04  N_PbIYhGR--4f8XFz1RZVA
+           Task  succeeded  2015-05-28T20:39:44      00:00:01  A 
+   ShellCommand  succeeded  2015-05-28T20:39:44      00:00:01  . execute
+           Task  succeeded  2015-05-28T20:39:45      00:00:01  B 
+   ShellCommand  succeeded  2015-05-28T20:39:45      00:00:00  . execute
+           Task  succeeded  2015-05-28T20:39:46      00:00:00  C 
+   ShellCommand  succeeded  2015-05-28T20:39:46      00:00:00  . execute

--- a/integration_tests/workflow_tests/shortcut_failure/workflow-view.txt
+++ b/integration_tests/workflow_tests/shortcut_failure/workflow-view.txt
@@ -1,5 +1,5 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:48      00:00:03           HIYRPvKwQyKhRcO_metlQA
-           Task  succeeded  2015-05-28T20:39:49      00:00:01           A 
-   ShellCommand     failed  2015-05-28T20:39:50      00:00:00           . shortcut
-   ShellCommand  succeeded  2015-05-28T20:39:50      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:48      00:00:03  HIYRPvKwQyKhRcO_metlQA
+           Task  succeeded  2015-05-28T20:39:49      00:00:01  A 
+   ShellCommand     failed  2015-05-28T20:39:50      00:00:00  . shortcut
+   ShellCommand  succeeded  2015-05-28T20:39:50      00:00:00  . execute

--- a/integration_tests/workflow_tests/shortcut_success/workflow-view.txt
+++ b/integration_tests/workflow_tests/shortcut_success/workflow-view.txt
@@ -1,5 +1,5 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:52      00:00:02           7jFfutcARLigHBJDerXQmA
-           Task  succeeded  2015-05-28T20:39:53      00:00:01           A 
-   ShellCommand  succeeded  2015-05-28T20:39:54      00:00:00           . shortcut
-   ShellCommand                                                         . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:52      00:00:02  7jFfutcARLigHBJDerXQmA
+           Task  succeeded  2015-05-28T20:39:53      00:00:01  A 
+   ShellCommand  succeeded  2015-05-28T20:39:54      00:00:00  . shortcut
+   ShellCommand                                                . execute

--- a/integration_tests/workflow_tests/single_operation/workflow-view.txt
+++ b/integration_tests/workflow_tests/single_operation/workflow-view.txt
@@ -1,4 +1,4 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:56      00:00:01           dzp2a3EIQMmjO3R5jzvY-w
-           Task  succeeded  2015-05-28T20:39:56      00:00:01           A 
-   ShellCommand  succeeded  2015-05-28T20:39:57      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:56      00:00:01  dzp2a3EIQMmjO3R5jzvY-w
+           Task  succeeded  2015-05-28T20:39:56      00:00:01  A 
+   ShellCommand  succeeded  2015-05-28T20:39:57      00:00:00  . execute

--- a/integration_tests/workflow_tests/spawned_simple_workflow/workflow-view.txt
+++ b/integration_tests/workflow_tests/spawned_simple_workflow/workflow-view.txt
@@ -1,5 +1,5 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-07-31T21:53:33      00:00:03           Perl SDK Integration Test (spawned_simple_workflow) 96B6FFE8-37CE-11E5-BF8C-EE8FC5871DAF
-           Task  succeeded  2015-07-31T21:53:34      00:00:02           A 
-   ShellCommand  succeeded  2015-07-31T21:53:35      00:00:01           . execute
-       Workflow  succeeded  2015-07-31T21:53:35      00:00:00           . . Perl SDK Integration Test (spawned_workflow) 979EF65E-37CE-11E5-A125-F38FC5871DAF
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-07-31T21:53:33      00:00:03  Perl SDK Integration Test (spawned_simple_workflow) 96B6FFE8-37CE-11E5-BF8C-EE8FC5871DAF
+           Task  succeeded  2015-07-31T21:53:34      00:00:02  A 
+   ShellCommand  succeeded  2015-07-31T21:53:35      00:00:01  . execute
+       Workflow  succeeded  2015-07-31T21:53:35      00:00:00  . . Perl SDK Integration Test (spawned_workflow) 979EF65E-37CE-11E5-A125-F38FC5871DAF

--- a/integration_tests/workflow_tests/split_outputs/workflow-view.txt
+++ b/integration_tests/workflow_tests/split_outputs/workflow-view.txt
@@ -1,8 +1,8 @@
-           TYPE     STATUS              STARTED      DURATION  P-INDEX  NAME
-       Workflow  succeeded  2015-05-28T20:39:59      00:00:04           gm2J3SCPTXGsS2_9j5GJuA
-           Task  succeeded  2015-05-28T20:40:00      00:00:01           A 
-   ShellCommand  succeeded  2015-05-28T20:40:00      00:00:00           . execute
-           Task  succeeded  2015-05-28T20:40:01      00:00:01           B 
-   ShellCommand  succeeded  2015-05-28T20:40:02      00:00:00           . execute
-           Task  succeeded  2015-05-28T20:40:01      00:00:01           C 
-   ShellCommand  succeeded  2015-05-28T20:40:02      00:00:00           . execute
+           TYPE     STATUS              STARTED      DURATION  NAME
+       Workflow  succeeded  2015-05-28T20:39:59      00:00:04  gm2J3SCPTXGsS2_9j5GJuA
+           Task  succeeded  2015-05-28T20:40:00      00:00:01  A 
+   ShellCommand  succeeded  2015-05-28T20:40:00      00:00:00  . execute
+           Task  succeeded  2015-05-28T20:40:01      00:00:01  B 
+   ShellCommand  succeeded  2015-05-28T20:40:02      00:00:00  . execute
+           Task  succeeded  2015-05-28T20:40:01      00:00:01  C 
+   ShellCommand  succeeded  2015-05-28T20:40:02      00:00:00  . execute

--- a/lib/Ptero/Concrete/Workflow/ReportWriter.pm
+++ b/lib/Ptero/Concrete/Workflow/ReportWriter.pm
@@ -3,6 +3,11 @@ package Ptero::Concrete::Workflow::ReportWriter;
 use strict;
 use warnings FATAL => 'all';
 use Params::Validate qw(validate validate_pos :types);
+use Ptero::Statuses qw(
+    is_abnormal
+    is_running
+);
+use Ptero::Proxy::Workflow::Execution;
 
 my $INDENTATION_STR = '. ';
 my $FORMAT_LINE = "%15s %10s %20s %13s  %s%s\n";
@@ -13,6 +18,7 @@ sub new {
 
     my $self = {
         handle => $handle,
+        executions_of_interest => {},
     };
 
     return bless $self, $class;
@@ -29,6 +35,7 @@ sub write_report {
 
     $self->write_header;
     $self->report_on_workflow($workflow, 0, 0);
+    $self->report_on_abnormal_executions();
 }
 
 sub write_header {
@@ -98,6 +105,11 @@ sub report_on_task {
             $execution->duration,
             $INDENTATION_STR x $indent,
             $task_name . ' ' . $parallel_by_str);
+
+        if (is_abnormal($execution->{status})) {
+            push @{$self->{executions_of_interest}->{task}},
+                $execution;
+        }
     } elsif (scalar(keys %{$task->{executions}}) == 0) {
         $self->printf($FORMAT_LINE,
             'Task',
@@ -141,6 +153,13 @@ sub report_on_method {
             my $concrete_workflow = $wf_proxy->concrete_workflow;
             $self->report_on_workflow($concrete_workflow, $indent+1, 0);
         }
+
+        if (is_abnormal($execution->{status}) or
+                is_running($execution->{status})) {
+            my $service = $method->{service};
+            push @{$self->{executions_of_interest}->{$service}},
+                $execution;
+        }
     } elsif (scalar(keys %{$method->{executions}}) == 0) {
         $self->printf($FORMAT_LINE,
             $DISPLAY_NAMES->{$method->{service}},
@@ -161,6 +180,82 @@ sub report_on_method {
     }
 
     return;
+}
+
+sub report_on_abnormal_executions {
+    my $self = shift;
+
+    return unless scalar(keys %{$self->{executions_of_interest}});
+
+    $self->printf("\n");
+    while (my ($service, $executions) =
+            each(%{$self->{executions_of_interest}})) {
+        for my $execution (@{$executions}) {
+            my $proxy = Ptero::Proxy::Workflow::Execution->new(
+                $execution->{details_url}
+            );
+            $self->report_on_execution($proxy, $service);
+            $self->printf("\n");
+        }
+    }
+}
+
+my $EXECUTION_REPORT_METHODS = {
+    'shell-command' => 'report_on_shell_command_execution',
+};
+
+sub report_on_execution {
+    my ($self, $proxy, $service) = @_;
+
+    my $accessor = $EXECUTION_REPORT_METHODS->{$service};
+
+    if ($accessor) {
+        $self->$accessor($proxy, $service);
+    } else {
+        $self->report_on_basic_execution($proxy, $service);
+    }
+}
+
+sub report_on_basic_execution {
+    my ($self, $proxy, $service) = @_;
+
+    $self->printf("  status: %s    name: %s\n", 
+        $proxy->concrete_execution->{status},
+        $proxy->name);
+    $self->printf("  service: %s\n", $service);
+    $self->printf("  details url: %s\n", $proxy->url);
+    my $error = $proxy->data->{error};
+    if ($error) {
+        $self->printf("  error: %s\n", $error);
+    }
+}
+
+sub report_on_shell_command_execution {
+    my ($self, $proxy, $service) = @_;
+
+    $self->report_on_basic_execution($proxy, $service);
+
+    my $error = $proxy->data->{errorMessage};
+    if ($error) {
+        $self->printf("  error: %s\n", $error);
+    }
+
+    my $exit_code = $proxy->data->{exitCode};
+    if ($exit_code) {
+        $self->printf("  exit code: %s\n", $exit_code);
+    }
+
+    my $stdout = $proxy->data->{stdout};
+    if ($stdout) {
+        chomp($stdout);
+        $self->printf("  stdout:\n%s\n", $stdout);
+    }
+
+    my $stderr = $proxy->data->{stderr};
+    if ($stderr) {
+        chomp($stderr);
+        $self->printf("  stderr:\n%s\n", $stderr);
+    }
 }
 
 1;

--- a/lib/Ptero/Concrete/Workflow/Task.pm
+++ b/lib/Ptero/Concrete/Workflow/Task.pm
@@ -53,7 +53,7 @@ sub executions_with_parent_color {
             push @executions, $execution;
         }
     }
-    return @executions;
+    return sort {$a->{color} <=> $b->{color}} @executions;
 }
 
 1;

--- a/lib/Ptero/Statuses.pm
+++ b/lib/Ptero/Statuses.pm
@@ -7,6 +7,8 @@ use Exporter 'import';
 our @EXPORT_OK = qw(
     is_terminal
     is_success
+    is_abnormal
+    is_running
 );
 
 my $TERMINAL_STATUSES = Set::Scalar->new(qw(errored failed succeeded canceled));
@@ -19,6 +21,16 @@ sub is_terminal {
 sub is_success {
     my $status = shift;
     return $status eq 'succeeded';
+}
+
+sub is_abnormal {
+    my $status = shift;
+    return (is_terminal($status) and !is_success($status));
+}
+
+sub is_running {
+    my $status = shift;
+    return $status eq 'running';
 }
 
 


### PR DESCRIPTION
1) Tasks that are 'parallel-by' are fully shown (one line per parallel
index)
2) Tasks that are 'parallel-by' are shown in order (ascending parallel
index)
3) Parallel index column goes away, parallel index is next to Task name.
4) Interesting execution data is shown after workflow is displayed.

Closes #82 