### PR TITLE
Validate submit env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You could also setup Carton using the system Perl on Debian-based Linux:
 
 Once your have Carton:
 
-    $ carton install --deployment # from the root of this repo
+    $ carton install # from the root of this repo
 
 To run tests:
 

--- a/integration_tests/post_basic_workflow.t
+++ b/integration_tests/post_basic_workflow.t
@@ -7,10 +7,13 @@ use Ptero::Test::Utils qw(
     repo_relative_path
     get_environment
     get_test_name
+    validate_submit_environment
 );
 
 use_ok('Ptero::Builder::Workflow');
 use_ok('Ptero::Builder::ShellCommand');
+
+validate_submit_environment();
 
 my $test_input = 'example test input';
 my $workflow = create_echo_workflow();

--- a/integration_tests/post_long_workflow.t
+++ b/integration_tests/post_long_workflow.t
@@ -10,10 +10,13 @@ use Ptero::Test::Utils qw(
     repo_relative_path
     get_environment
     get_test_name
+    validate_submit_environment
 );
 
 use_ok('Ptero::Builder::Workflow');
 use_ok('Ptero::Builder::ShellCommand');
+
+validate_submit_environment();
 
 setup_logging();
 my $workflow = create_echo_workflow();

--- a/run-tests
+++ b/run-tests
@@ -8,5 +8,5 @@ else
     FILES=t/Ptero
 fi
 
-HARNESS_PERL_SWITCHES=-MDevel::Cover=+ignore,local carton exec prove -vrl $FILES
+HARNESS_PERL_SWITCHES=-MDevel::Cover=+ignore,local carton exec prove -vrl -It $FILES
 carton exec cover -report html


### PR DESCRIPTION
The integration tests would fail without explaining that PTERO_WORKFLOW_EXECUTION_URL and PTERO_WORKFLOW_SUBMIT_URL environment variables needed to be set.

This PR enables validation before running the tests.