### PR TITLE
Add framework for tested examples

### DIFF
--- a/docs/examples/single_task.md
+++ b/docs/examples/single_task.md
@@ -1,0 +1,114 @@
+### Background
+
+This is an example of building a **Workflow** that consists of a single **Task** using the perl SDK.
+**Task**s represent some work that you want to get done.
+**Task**s can have inputs and produce outputs, but they don't have to, and in this example we neglect inputs and outputs.
+
+**Task**s represent the work to be done, but it is the job of the **Method**s to describe how a **Task** should be completed.
+A **Task** contains a list of **Methods** to try.
+When the **Task** is executed, these **Method**s are attempted in order until one succeeds or they all fail.
+
+### Example
+
+We start out by creating a workflow, all we need to do is name it.
+
+
+```perl
+use Ptero::Builder::Workflow;
+use Ptero::Builder::Detail::Workflow::Task;
+use Ptero::Builder::Job;
+
+my $workflow = Ptero::Builder::Workflow->new(name => "SomeWorkflow");
+```
+
+
+Since a **Task** represents work to be done, and not how the work should be done, it's easy to define.
+In fact, it only requires a name.
+To add a task to a workflow use the **->add_task** method.
+
+
+
+```perl
+my $task = Ptero::Builder::Detail::Workflow::Task->new(name => "SomeTask");
+$workflow->add_task($task);
+```
+
+
+To add a **Method** to a task, you can use the **->add_method** method like below.
+
+
+
+```perl
+my $method = Ptero::Builder::Job->new(
+    name => "SomeMethod",
+    service_url => "http://some-job-service.example.com/v1",
+    parameters => {
+        commandLine => [
+            'ptero-perl-subroutine-wrapper',
+            '--package' => 'Some::Perl::Module',
+            '--subroutine' => 'some_subroutine'
+        ],
+        environment => {PERL5LIB => '/path/to/some/perl/module'},
+        user => 'some_user',
+        workingDirectory => '/tmp',
+    },
+);
+$task->add_method($method);
+```
+
+
+Finally, we just need to add links to the **Workflow** to indicate when we want the task to run.
+In this case, we only have one task so it's a little silly but here's how its done:
+
+
+
+```perl
+$workflow->create_link(destination => $task);
+$workflow->create_link(source => $task);
+```
+
+
+This workflow, built up programmatically using the Perl SDK is equivalent to this JSON representation:
+
+
+
+```json
+{
+   "links" : [
+      {
+         "destination" : "SomeTask",
+         "source" : "input connector"
+      },
+      {
+         "destination" : "output connector",
+         "source" : "SomeTask"
+      }
+   ],
+   "tasks" : {
+      "SomeTask" : {
+         "methods" : [
+            {
+               "name" : "SomeMethod",
+               "parameters" : {
+                  "commandLine" : [
+                     "ptero-perl-subroutine-wrapper",
+                     "--package",
+                     "Some::Perl::Module",
+                     "--subroutine",
+                     "some_subroutine"
+                  ],
+                  "environment" : {
+                     "PERL5LIB" : "/path/to/some/perl/module"
+                  },
+                  "user" : "some_user",
+                  "workingDirectory" : "/tmp"
+               },
+               "service" : "job",
+               "serviceUrl" : "http://some-job-service.example.com/v1"
+            }
+         ]
+      }
+   }
+}
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+# PTero Perl SDK Documentation

--- a/examples/single_task.t
+++ b/examples/single_task.t
@@ -1,0 +1,122 @@
+use strict;
+use warnings FATAL => 'all';
+
+use Test::More;
+use Ptero::Test::Utils qw(process_into_markdown is_same);
+
+#|### Background
+#|
+#|This is an example of building a **Workflow** that consists of a single **Task** using the perl SDK.
+#|**Task**s represent some work that you want to get done.
+#|**Task**s can have inputs and produce outputs, but they don't have to, and in this example we neglect inputs and outputs.
+#|
+#|**Task**s represent the work to be done, but it is the job of the **Method**s to describe how a **Task** should be completed.
+#|A **Task** contains a list of **Methods** to try.
+#|When the **Task** is executed, these **Method**s are attempted in order until one succeeds or they all fail.
+#|
+#|### Example
+#|
+#|We start out by creating a workflow, all we need to do is name it.
+
+#<<perl
+use Ptero::Builder::Workflow;
+use Ptero::Builder::Detail::Workflow::Task;
+use Ptero::Builder::Job;
+
+my $workflow = Ptero::Builder::Workflow->new(name => "SomeWorkflow");
+#<<
+
+#|
+#|Since a **Task** represents work to be done, and not how the work should be done, it's easy to define.
+#|In fact, it only requires a name.
+#|To add a task to a workflow use the **->add_task** method.
+#|
+
+
+#<<perl
+my $task = Ptero::Builder::Detail::Workflow::Task->new(name => "SomeTask");
+$workflow->add_task($task);
+#<<
+
+#|
+#|To add a **Method** to a task, you can use the **->add_method** method like below.
+#|
+
+#<<perl
+my $method = Ptero::Builder::Job->new(
+    name => "SomeMethod",
+    service_url => "http://some-job-service.example.com/v1",
+    parameters => {
+        commandLine => [
+            'ptero-perl-subroutine-wrapper',
+            '--package' => 'Some::Perl::Module',
+            '--subroutine' => 'some_subroutine'
+        ],
+        environment => {PERL5LIB => '/path/to/some/perl/module'},
+        user => 'some_user',
+        workingDirectory => '/tmp',
+    },
+);
+$task->add_method($method);
+#<<
+
+#|
+#|Finally, we just need to add links to the **Workflow** to indicate when we want the task to run.
+#|In this case, we only have one task so it's a little silly but here's how its done:
+#|
+
+#<<perl
+$workflow->create_link(destination => $task);
+$workflow->create_link(source => $task);
+#<<
+
+#|
+#|This workflow, built up programmatically using the Perl SDK is equivalent to this JSON representation:
+#|
+
+my $expected_result = <<EOS;
+#<<json
+{
+   "links" : [
+      {
+         "destination" : "SomeTask",
+         "source" : "input connector"
+      },
+      {
+         "destination" : "output connector",
+         "source" : "SomeTask"
+      }
+   ],
+   "tasks" : {
+      "SomeTask" : {
+         "methods" : [
+            {
+               "name" : "SomeMethod",
+               "parameters" : {
+                  "commandLine" : [
+                     "ptero-perl-subroutine-wrapper",
+                     "--package",
+                     "Some::Perl::Module",
+                     "--subroutine",
+                     "some_subroutine"
+                  ],
+                  "environment" : {
+                     "PERL5LIB" : "/path/to/some/perl/module"
+                  },
+                  "user" : "some_user",
+                  "workingDirectory" : "/tmp"
+               },
+               "service" : "job",
+               "serviceUrl" : "http://some-job-service.example.com/v1"
+            }
+         ]
+      }
+   }
+}
+#<<
+EOS
+
+is_same($workflow->to_json(), $expected_result, 'single task example') || die;
+
+done_testing();
+process_into_markdown(__FILE__);

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: PTero Perl SDK
+pages:
+    - Home: index.md
+    - Examples:
+        - 'Single Task': 'examples/single_task.md'
+theme: readthedocs


### PR DESCRIPTION
Examples are just .t files that run like any other test.  They are
marked up with special comments:

The tests include a call to a subroutine to process the test file into
markdown.  That markdown file lives in the docs/examples folder and
should be included in the mkdocs.yml in order to show up on readthedocs.

To preview the docs:

$ sudo pip install mkdocs
$ mkdocs serve -a 0.0.0.0:8000

then on your host machine go to http://192.168.20.20:8000

![image](https://cloud.githubusercontent.com/assets/650482/10252569/ec6ea4c6-68fd-11e5-96f1-b0d50826fb0d.png)
