### PR TITLE
Only set the Content-Type for https requests which send data

### DIFF
--- a/lib/Ptero/HTTP.pm
+++ b/lib/Ptero/HTTP.pm
@@ -59,7 +59,6 @@ sub make_request {
     my @headers = (
         'Accept' => 'application/json',
         'Accept-Encoding' => 'gzip',
-        'Content-Type' => 'application/json',
     );
 
     my @request_args = ($method, $url);
@@ -70,6 +69,7 @@ sub make_request {
         } else {
             gzip(\$_json_codec->encode($data), \$content);
             push @headers, 'Content-Encoding' => 'gzip';
+            push @headers, 'Content-Type' => 'application/json';
         }
         push @headers, 'Content-Length' => length $content;
         push @request_args, \@headers, $content;


### PR DESCRIPTION
The ptero-perl-sdk was always setting the http `Content-Type` header to `application/json`.  This header indicates the MIME type of the request body.  GET requests have no request body.  Therefore the `Content-Type` header should not be set for a GET request.

During the PTero Submodule Update test, the tests were failing to get workflow URLs such as `http://localhost:7000/v1/reports/workflow-status?workflow_id=22`.  The web server would respond with "400 Bad Request".  It is not entirely clear to me why this error was not caught in other test environments.