### PR TITLE
Make _parse_datetime() able to parse our dates

### DIFF
--- a/lib/Ptero/Concrete/Workflow/Execution.pm
+++ b/lib/Ptero/Concrete/Workflow/Execution.pm
@@ -104,7 +104,10 @@ sub _parse_datetime {
     my $self = shift;
     my ($time) = @_;
 
-    my $pattern = '%Y-%m-%d %H:%M:%S';
+    # Convert timezone: e.g., '-05:00' -> '-5000'
+    $time =~ s/([-+]\d{2}):(\d{2})$/$1$2/;
+
+    my $pattern = '%Y-%m-%d %H:%M:%S.%6N%z';
     my $parser = DateTime::Format::Strptime->new(pattern => $pattern);
 
     my $datetime = $parser->parse_datetime($time);


### PR DESCRIPTION
DateTime::Format::Strptime suddenly stopped parsing our timestamps which
look like '2015-08-28 15:48:46.233723-05:00'.  The format we had been
using obviously should not have worked on those timestamps, but seemed
to have worked anyway until today.

I didn't investigate very deeply, but I suspect that the
DateTime::Format::Strptime library author changed this functionality in
a recent release.