### PR TITLE
Ptero glance

### DIFF
--- a/bin/ptero-glance
+++ b/bin/ptero-glance
@@ -1,0 +1,169 @@
+#! /usr/bin/env perl
+
+use strict;
+use warnings FATAL => 'all';
+
+use Getopt::Long;
+use Ptero::Proxy::Workflow;
+use Ptero::Statuses qw(has_letter);
+
+use Log::Log4perl qw(:easy);
+
+my $INDENTATION_STR = '. ';
+my $FORMAT_LINE = "%35s %9s  %s%s\n";
+my $DISPLAY_NAMES = {
+    'workflow' => 'DAG',
+    'job' => 'Job',
+};
+
+exit main();
+
+sub main {
+    my $workflow_url = get_options();
+
+    my $wf_proxy = Ptero::Proxy::Workflow->new($workflow_url);
+
+    my $summary = $wf_proxy->workflow_summary();
+    display_workflow($summary);
+}
+
+sub get_options {
+    my $usage = <<'EOS';
+Usage: ptero-glance <workflow_url>
+
+Prints a summary view of the workflow to the screen.
+
+If there are multiple executions of a Task or Method, a one-line summary is
+shown.  The following single-letter abbreviations of statuses are used:
+EOS
+
+    for my $status qw(canceled scheduled errored failed running succeeded) {
+        $usage .= sprintf("  %s = %s\n", has_letter($status), $status);
+    }
+    $usage .= sprintf("The letter %s is used for status values not listed above.\n",
+        has_letter("some unknown status"));
+
+    my $help;
+    unless (GetOptions('help|h!'    => \$help)) {
+        print STDERR $usage;
+        exit 1;
+    }
+
+    if (defined($help)) {
+        print STDERR $usage;
+        exit 0;
+    }
+
+    if (scalar @ARGV != 1) {
+        print STDERR "Wrong number of positional arguments!\n";
+        print STDERR $usage;
+        exit 1;
+    }
+
+    return shift @ARGV;
+}
+
+sub display_workflow {
+    my $summary = shift;
+
+    write_header();
+    write_workflow_info($summary->{name}, $summary->{status});
+    for my $task_summary (@{$summary->{tasks}}) {
+        display_task($task_summary, 1);
+    }
+}
+
+sub write_header {
+    my $self = shift;
+
+    printf($FORMAT_LINE,
+        'STATUS SUMMARY',
+        'TYPE',
+        '',
+        'NAME');
+
+    return
+}
+
+sub write_workflow_info {
+    my ($name, $status) = @_;
+    printf($FORMAT_LINE,
+        $status,
+        'Workflow',
+        '',
+        $name);
+}
+
+sub display_task {
+    my ($task_summary, $indent) = @_;
+
+    write_task($task_summary, $indent);
+
+    for my $method_summary (@{$task_summary->{methods}}) {
+        display_method($method_summary, $indent + 1);
+    }
+}
+
+sub write_task {
+    my ($task_summary, $indent) = @_;
+
+    my $display_name = $task_summary->{name};
+    if (exists $task_summary->{parallelBy}) {
+        $display_name .= sprintf(" [parallel-by: %s]",
+            $task_summary->{parallelBy});
+    }
+    my $status_summary = format_execution_summary(
+        $task_summary->{executionSummary});
+
+    printf($FORMAT_LINE,
+        $status_summary,
+        'Task',
+        $INDENTATION_STR x $indent,
+        $display_name);
+}
+
+sub display_method {
+    my ($method_summary, $indent) = @_;
+
+    write_method($method_summary, $indent);
+
+    if ($method_summary->{service} eq 'workflow') {
+        for my $task_summary (@{$method_summary->{parameters}->{tasks}}) {
+            display_task($task_summary, $indent + 1);
+        }
+    }
+}
+
+sub write_method {
+    my ($method_summary, $indent) = @_;
+
+    my $name = $method_summary->{name};
+    my $status_summary = format_execution_summary(
+        $method_summary->{executionSummary});
+    my $type = $DISPLAY_NAMES->{$method_summary->{service}};
+
+    printf($FORMAT_LINE,
+        $status_summary,
+        $type,
+        $INDENTATION_STR x $indent,
+        $name);
+}
+
+sub format_execution_summary {
+    my $summary = shift;
+
+    # if only one status in the summary
+    if (scalar(keys %$summary) == 1) {
+        my @summary_array = %$summary;
+        if ($summary_array[-1] == 1) {
+            return $summary_array[0];
+        }
+    }
+
+    my @parts;
+    while (my ($status, $num) = each %$summary) {
+        push @parts, sprintf("%s:%s", has_letter($status), $num);
+    }
+    return join(' ', sort(@parts));
+}
+

--- a/bin/ptero-glance
+++ b/bin/ptero-glance
@@ -5,7 +5,7 @@ use warnings FATAL => 'all';
 
 use Getopt::Long;
 use Ptero::Proxy::Workflow;
-use Ptero::Statuses qw(has_letter);
+use Ptero::Statuses qw(get_abbreviation);
 
 use Log::Log4perl qw(:easy);
 
@@ -38,10 +38,10 @@ shown.  The following single-letter abbreviations of statuses are used:
 EOS
 
     for my $status qw(canceled scheduled errored failed running succeeded) {
-        $usage .= sprintf("  %s = %s\n", has_letter($status), $status);
+        $usage .= sprintf("  %s = %s\n", get_abbreviation($status), $status);
     }
     $usage .= sprintf("The letter %s is used for status values not listed above.\n",
-        has_letter("some unknown status"));
+        get_abbreviation("some unknown status"));
 
     my $help;
     unless (GetOptions('help|h!'    => \$help)) {
@@ -162,7 +162,7 @@ sub format_execution_summary {
 
     my @parts;
     while (my ($status, $num) = each %$summary) {
-        push @parts, sprintf("%s:%s", has_letter($status), $num);
+        push @parts, sprintf("%s:%s", get_abbreviation($status), $num);
     }
     return join(' ', sort(@parts));
 }

--- a/lib/Ptero/Proxy/Workflow.pm
+++ b/lib/Ptero/Proxy/Workflow.pm
@@ -74,6 +74,12 @@ sub workflow_executions {
         url => $self->report_url('workflow-executions'));
 }
 
+sub workflow_summary {
+    my $self = shift;
+    return make_request_and_decode_response(method => 'GET',
+        url => $self->report_url('workflow-summary'));
+}
+
 sub cancel {
     my $self = shift;
     make_request_and_decode_response(method => 'PATCH', url => $self->url,

--- a/lib/Ptero/Statuses.pm
+++ b/lib/Ptero/Statuses.pm
@@ -9,6 +9,7 @@ our @EXPORT_OK = qw(
     is_success
     is_abnormal
     is_running
+    has_letter
 );
 
 my $TERMINAL_STATUSES = Set::Scalar->new(qw(errored failed succeeded canceled));
@@ -31,6 +32,22 @@ sub is_abnormal {
 sub is_running {
     my $status = shift;
     return $status eq 'running';
+}
+
+
+my %STATUS_LETTERS = (
+    'new' => 'N',
+    'scheduled' => 'D',
+    'running' => 'R',
+    'succeeded' => 'S',
+    'failed' => 'F',
+    'errored' => 'E',
+    'canceled' => 'C',
+);
+
+sub has_letter {
+    my $status = shift;
+    return $STATUS_LETTERS{$status} || "U";
 }
 
 

--- a/lib/Ptero/Statuses.pm
+++ b/lib/Ptero/Statuses.pm
@@ -9,7 +9,7 @@ our @EXPORT_OK = qw(
     is_success
     is_abnormal
     is_running
-    has_letter
+    get_abbreviation
 );
 
 my $TERMINAL_STATUSES = Set::Scalar->new(qw(errored failed succeeded canceled));
@@ -45,7 +45,7 @@ my %STATUS_LETTERS = (
     'canceled' => 'C',
 );
 
-sub has_letter {
+sub get_abbreviation {
     my $status = shift;
     return $STATUS_LETTERS{$status} || "U";
 }


### PR DESCRIPTION
Example:
```
$ carton exec -- perl -I lib bin/ptero-glance http://localhost:7000/v1/workflows/2
                     STATUS SUMMARY      TYPE  NAME
                            running  Workflow  f6947e8d-89b5-4c67-a721-621239d2b4c5
                            R:4 S:2      Task  . DAG Task [parallel-by: dag_in]
                            R:3 S:2       DAG  . . Inner DAG
                        R:258 S:247      Task  . . . Job Task [parallel-by: job_in]
                    D:253 R:2 S:245       Job  . . . . Echo
```

Help/Usage statement:
```
$ carton exec -- perl -I lib bin/ptero-glance http://localhost:7000/v1/workflows/1 foo
Wrong number of positional arguments!
Usage: ptero-glance <workflow_url>

Prints a summary view of the workflow to the screen.

If there are multiple executions of a Task or Method, a one-line summary is
shown.  The following single-letter abbreviations of statuses are used:
  C = canceled
  D = scheduled
  E = errored
  F = failed
  R = running
  S = succeeded
The letter U is used for status values not listed above.
```