### PR TITLE
Ensure workflows have expected status

### DIFF
--- a/integration_tests/workflow_tests/control_flow/result.json
+++ b/integration_tests/workflow_tests/control_flow/result.json
@@ -1,3 +1,4 @@
 {
-    "outputs": null
+    "outputs": null,
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/lsf_single_operation/result.json
+++ b/integration_tests/workflow_tests/lsf_single_operation/result.json
@@ -1,5 +1,6 @@
 {
     "outputs": {
         "out_a": "kittens"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/n_shaped/result.json
+++ b/integration_tests/workflow_tests/n_shaped/result.json
@@ -3,5 +3,6 @@
         "out_c": "foo",
         "out_d_1": "bar",
         "out_d_2": "baz"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/n_shaped_with_block/result.json
+++ b/integration_tests/workflow_tests/n_shaped_with_block/result.json
@@ -5,5 +5,6 @@
         "out_c": "foo",
         "out_d_1": "bar",
         "out_d_2": "baz"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/nested/result.json
+++ b/integration_tests/workflow_tests/nested/result.json
@@ -2,5 +2,6 @@
     "outputs": {
         "outer_out_c_1": "ferret",
         "outer_out_c_2": "badger"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/result.json
+++ b/integration_tests/workflow_tests/nested_parallel_by_dag_orthogonal_inputs/result.json
@@ -8,5 +8,6 @@
             ["Simba", "Tabby", "Emilio"],
             ["Simba", "Tabby", "Emilio"]
         ]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/nested_parallel_by_operation_matrix_inputs/result.json
+++ b/integration_tests/workflow_tests/nested_parallel_by_operation_matrix_inputs/result.json
@@ -4,5 +4,6 @@
             ["Simba", "Tabby", "Emilio"],
             ["Pluto", "Snoopy"]
         ]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/result.json
+++ b/integration_tests/workflow_tests/nested_parallel_by_operation_orthogonal_inputs/result.json
@@ -8,5 +8,6 @@
             ["Simba", "Tabby", "Emilio"],
             ["Simba", "Tabby", "Emilio"]
         ]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/parallel_by_dag/result.json
+++ b/integration_tests/workflow_tests/parallel_by_dag/result.json
@@ -2,5 +2,6 @@
     "outputs": {
         "out_constant": ["kittens", "kittens", "kittens"],
         "out_parallel": ["Simba", "Tabby", "Emilio"]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/parallel_by_dag_pass_through/result.json
+++ b/integration_tests/workflow_tests/parallel_by_dag_pass_through/result.json
@@ -2,5 +2,6 @@
     "outputs": {
         "out_constant": ["kittens", "kittens", "kittens"],
         "out_parallel": ["Simba", "Tabby", "Emilio"]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/parallel_by_nested_dag/result.json
+++ b/integration_tests/workflow_tests/parallel_by_nested_dag/result.json
@@ -2,5 +2,6 @@
     "outputs": {
         "out_constant": ["kittens", "kittens", "kittens"],
         "out_parallel": ["Simba", "Tabby", "Emilio"]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/parallel_by_operation/result.json
+++ b/integration_tests/workflow_tests/parallel_by_operation/result.json
@@ -2,5 +2,6 @@
     "outputs": {
         "out_constant": ["kittens", "kittens", "kittens"],
         "out_parallel": ["Simba", "Tabby", "Emilio"]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/sequential_parallel_by/result.json
+++ b/integration_tests/workflow_tests/sequential_parallel_by/result.json
@@ -6,5 +6,6 @@
             ["kittens", "kittens", "kittens"]
         ],
         "out_parallel": ["Simba", "Tabby", "Emilio"]
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/serial/result.json
+++ b/integration_tests/workflow_tests/serial/result.json
@@ -1,5 +1,6 @@
 {
     "outputs": {
         "out_val": "walruses"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/shortcut_failure/result.json
+++ b/integration_tests/workflow_tests/shortcut_failure/result.json
@@ -1,5 +1,6 @@
 {
     "outputs": {
         "out_a": "kittens"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/shortcut_success/result.json
+++ b/integration_tests/workflow_tests/shortcut_success/result.json
@@ -1,5 +1,6 @@
 {
     "outputs": {
         "out_a": "kittens"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/single_operation/result.json
+++ b/integration_tests/workflow_tests/single_operation/result.json
@@ -1,5 +1,6 @@
 {
     "outputs": {
         "out_a": "kittens"
-    }
+    },
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/spawned_simple_workflow/result.json
+++ b/integration_tests/workflow_tests/spawned_simple_workflow/result.json
@@ -1,3 +1,4 @@
 {
-    "outputs": null
+    "outputs": null,
+    "status": "succeeded"
 }

--- a/integration_tests/workflow_tests/split_outputs/result.json
+++ b/integration_tests/workflow_tests/split_outputs/result.json
@@ -2,5 +2,6 @@
     "outputs": {
         "out_1": "parrots",
         "out_2": "toucans"
-    }
+    },
+    "status": "succeeded"
 }

--- a/t/Ptero/Test/Integration.pm
+++ b/t/Ptero/Test/Integration.pm
@@ -114,7 +114,10 @@ sub run_test {
     $wf_proxy->wait(polling_interval => 1);
 
     my $result_file = File::Spec->join($dir, 'result.json');
-    is_deeply($wf_proxy->outputs, get_expected_outputs($result_file), 'Got expected outputs');
+
+    my $results = get_expected_results($result_file);
+    is($wf_proxy->status, $results->{status}, 'Got expected status') or die;
+    is_deeply($wf_proxy->outputs, $results->{outputs}, 'Got expected outputs') or die;
 
     my $cache_file = File::Spec->join($dir, 'http-response-cache.json');
 
@@ -181,13 +184,13 @@ sub get_workflow_inputs {
     return $hashref->{inputs} || die "Couldn't find inputs in file '$workflow_json'";
 }
 
-sub get_expected_outputs {
+sub get_expected_results {
     my $filename = shift;
 
     my $json_text = read_file($filename);
     my $hashref = from_json($json_text);
-    note "No outputs found in file '$filename'" unless ($hashref);
-    return $hashref->{outputs};
+    note "No results found in file '$filename'" unless ($hashref);
+    return $hashref;
 }
 
 sub get_workflow_json {


### PR DESCRIPTION
We were only checking that the outputs were as expected.  Sometimes we
expect no outputs but want to make sure that the workflow succeeded.
Since the outputs will be unset if the workflow fails, it wasn't enough
to simply check that the outputs were unset.