### PR TITLE
No longer retry 404 Not Found

### DIFF
--- a/lib/Ptero/HTTP.pm
+++ b/lib/Ptero/HTTP.pm
@@ -31,6 +31,7 @@ for (1..20) {
 my @RETRY_DELAYS = map {$_ + _random_int(4)} @RAW_DELAYS;
 
 my @CODES_TO_RETRY = (
+    404,  # Not Found
     408,  # Request Timeout
     500,  # Internal Server Error
     502,  # Bad Gateway


### PR DESCRIPTION
This decision is in large part because the Deis Router returns 404 when
an the web server for an application is scaled down.  It should be
returning 503 instead, but this issue is not likely going to be fixed
anytime soon.

https://github.com/deis/deis/issues/4778