### PR TITLE
"use Set::Scalar" before using Set::Scalar.

### DIFF
--- a/lib/Ptero/Statuses.pm
+++ b/lib/Ptero/Statuses.pm
@@ -12,6 +12,7 @@ our @EXPORT_OK = qw(
     get_abbreviation
 );
 
+use Set::Scalar;
 my $TERMINAL_STATUSES = Set::Scalar->new(qw(errored failed succeeded canceled));
 
 sub is_terminal {


### PR DESCRIPTION
I started using `Ptero::Statuses` in `Genome::Model::Build`, and tests are failing for lack of this module.