### PR TITLE
LSF translates %J, so let's translate it, too!

### DIFF
--- a/bin/ptero-lsf-post-exec
+++ b/bin/ptero-lsf-post-exec
@@ -51,6 +51,11 @@ sub determine_update_values {
     my $stderr = $lsf_data->{options}{errFile};
     my $stdout = $lsf_data->{options}{outFile};
 
+    my $lsf_job_id = $lsf_data->{lsfJobId};
+
+    $stderr =~ s/\Q%J\E/$lsf_job_id/;
+    $stdout =~ s/\Q%J\E/$lsf_job_id/;
+
     if (defined($stderr) && -e $stderr) {
         $values->{stderr} = fetch_contents($stderr, $character_limit);
         unlink $stderr;


### PR DESCRIPTION
It'd be better if we queried LSF to determine these log paths.  Then we get all the substitutions that might've been made.  (LSF supports a few other % sequences as well.)  But this at least satisfies our use-case.
